### PR TITLE
feat(invoices): migrate hardcoded UI strings to Transloco

### DIFF
--- a/ordermanager-ui/ui/resources/frontend/invoices/package.json
+++ b/ordermanager-ui/ui/resources/frontend/invoices/package.json
@@ -23,6 +23,8 @@
     "@angular/platform-browser-dynamic": "^18.2.14",
     "@angular/router": "^18.2.14",
     "@fullcalendar/core": "^5.3.1",
+    "@jsverse/transloco": "^8.3.0",
+    "@jsverse/transloco-messageformat": "^8.3.0",
     "@ngrx/effects": "^18.1.1",
     "@ngrx/entity": "^18.1.1",
     "@ngrx/store": "^18.1.1",
@@ -45,6 +47,7 @@
     "primeflex": "^2.0.0",
     "primeicons": "^7.0.0",
     "primeng": "^18.0.2",
+    "protractor": "^7.0.0",
     "rimraf": "^4.4.1",
     "rxjs": "~7.8.1",
     "save": "^2.9.0",
@@ -52,9 +55,7 @@
     "timers-browserify-full": "^0.0.1",
     "tslib": "^2.0.1",
     "uuid": "^9.0.0",
-    "zone.js": "^0.14.6",
-    "@jsverse/transloco": "^8.3.0",
-    "@jsverse/transloco-messageformat": "^8.3.0"
+    "zone.js": "^0.14.6"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^18.2.21",

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/app.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/app.component.html
@@ -1,9 +1,9 @@
 @if (!isAuthenticated()) {
 <div  class="p-grid  app_title p-shadow-4">
   <!--  <p-button  label="Home" (click)="router.navigateByUrl('/')"></p-button>-->
-  <a (click)="router.navigateByUrl('/')" [pTooltip]="'Navigate to home page'" [tooltipPosition]="'right'"><img
+  <a (click)="router.navigateByUrl('/')" [pTooltip]="'app.tooltips.navigate_home' | transloco" [tooltipPosition]="'right'"><img
     src="assets/home-small.png"></a>
-  <h3 style="margin-left: 5pt;">Order manager</h3>
+  <h3 style="margin-left: 5pt;">{{ 'app.title' | transloco }}</h3>
 
 </div>
   <app-user-login></app-user-login>
@@ -12,7 +12,7 @@
   <div class="nav_app_cls p-grid p-shadow-4">
     <nav style="margin-bottom: 10pt;">
       <div class="p-grid">
-        <a (click)="router.navigateByUrl('/')" [pTooltip]="'Navigate to home page'"
+        <a (click)="router.navigateByUrl('/')" [pTooltip]="'app.tooltips.navigate_home' | transloco"
            [tooltipPosition]="'right'" style="margin-right: 10pt; margin-top: 8pt;margin-left: 10pt;"><img
           src="assets/home-small.png"></a>
         <p-menubar [model]="menuItems"></p-menubar>
@@ -20,7 +20,7 @@
     </nav>
   </div>
   <div *ngIf="this.router.url ==='/'" style="margin: 10pt 10pt 10pt 10pt;">
-    <h2>Homepage of Ordermanager Application</h2>
+    <h2>{{ 'app.homepage.heading' | transloco }}</h2>
   </div>
   <br/>
 </div>

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/app.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/app.component.html
@@ -1,9 +1,9 @@
 @if (!isAuthenticated()) {
 <div  class="p-grid  app_title p-shadow-4">
   <!--  <p-button  label="Home" (click)="router.navigateByUrl('/')"></p-button>-->
-  <a (click)="router.navigateByUrl('/')" [pTooltip]="'app.tooltips.navigate_home' | transloco" [tooltipPosition]="'right'"><img
+  <a (click)="router.navigateByUrl('/')" [pTooltip]="'tooltips.navigate_home' | transloco" [tooltipPosition]="'right'"><img
     src="assets/home-small.png"></a>
-  <h3 style="margin-left: 5pt;">{{ 'app.title' | transloco }}</h3>
+  <h3 style="margin-left: 5pt;">{{ 'title' | transloco }}</h3>
 
 </div>
   <app-user-login></app-user-login>
@@ -12,7 +12,7 @@
   <div class="nav_app_cls p-grid p-shadow-4">
     <nav style="margin-bottom: 10pt;">
       <div class="p-grid">
-        <a (click)="router.navigateByUrl('/')" [pTooltip]="'app.tooltips.navigate_home' | transloco"
+        <a (click)="router.navigateByUrl('/')" [pTooltip]="'tooltips.navigate_home' | transloco"
            [tooltipPosition]="'right'" style="margin-right: 10pt; margin-top: 8pt;margin-left: 10pt;"><img
           src="assets/home-small.png"></a>
         <p-menubar [model]="menuItems"></p-menubar>
@@ -20,7 +20,7 @@
     </nav>
   </div>
   <div *ngIf="this.router.url ==='/'" style="margin: 10pt 10pt 10pt 10pt;">
-    <h2>{{ 'app.homepage.heading' | transloco }}</h2>
+    <h2>{{ 'homepage.heading' | transloco }}</h2>
   </div>
   <br/>
 </div>

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/app.component.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/app.component.ts
@@ -29,40 +29,40 @@ export class AppComponent implements OnInit, AfterViewInit {
 
     this.menuItems = [
       {
-        label: this.translocoService.translate('app.menu.user_management'),
+        label: this.translocoService.translate('menu.user_management'),
         icon: 'pi pi-fw pi-users',
         items: [
-          {label: this.translocoService.translate('app.menu.create_user'), icon: 'pi pi-fw pi-user-plus', routerLink: '/user-registration-page'}
+          {label: this.translocoService.translate('menu.create_user'), icon: 'pi pi-fw pi-user-plus', routerLink: '/user-registration-page'}
         ]
       },
       {
-        label: this.translocoService.translate('app.menu.invoice.title'),
+        label: this.translocoService.translate('menu.invoice.title'),
         icon: 'pi pi-fw pi-book',
         items: [
-          {label: this.translocoService.translate('app.menu.invoice.create'), icon: 'pi pi-fw pi-plus', routerLink: '/create-invoice-page'},
-          {label: this.translocoService.translate('app.menu.invoice.create_catalog_item'), icon: 'pi pi-fw pi-plus', routerLink: '/create-invoice-item-page'},
-          {label: this.translocoService.translate('app.menu.invoice.manage_catalog_items'), icon: 'pi pi-fw pi-pencil', routerLink: '/catalog-item-management-page'},
-          {label: this.translocoService.translate('app.menu.invoice.management'), icon: 'pi pi-fw pi-pencil', routerLink: '/invoice-management_page'},
-          {label: this.translocoService.translate('app.menu.invoice.print'), icon: 'pi pi-fw pi-file-pdf', routerLink: '/invoice-list_page'}
+          {label: this.translocoService.translate('menu.invoice.create'), icon: 'pi pi-fw pi-plus', routerLink: '/create-invoice-page'},
+          {label: this.translocoService.translate('menu.invoice.create_catalog_item'), icon: 'pi pi-fw pi-plus', routerLink: '/create-invoice-item-page'},
+          {label: this.translocoService.translate('menu.invoice.manage_catalog_items'), icon: 'pi pi-fw pi-pencil', routerLink: '/catalog-item-management-page'},
+          {label: this.translocoService.translate('menu.invoice.management'), icon: 'pi pi-fw pi-pencil', routerLink: '/invoice-management_page'},
+          {label: this.translocoService.translate('menu.invoice.print'), icon: 'pi pi-fw pi-file-pdf', routerLink: '/invoice-list_page'}
         ]
       },
       {
-        label: this.translocoService.translate('app.menu.person.title'),
+        label: this.translocoService.translate('menu.person.title'),
         icon: 'pi pi-fw pi-user',
         items: [
-          {label: this.translocoService.translate('app.menu.person.create'), icon: 'pi pi-fw pi-plus', routerLink: '/create-person_page'},
-          {label: this.translocoService.translate('app.menu.person.management'), icon: 'pi pi-fw pi-pencil', routerLink: '/person-management-page'}
+          {label: this.translocoService.translate('menu.person.create'), icon: 'pi pi-fw pi-plus', routerLink: '/create-person_page'},
+          {label: this.translocoService.translate('menu.person.management'), icon: 'pi pi-fw pi-pencil', routerLink: '/person-management-page'}
         ]
       },
       {
-        label: this.translocoService.translate('app.menu.workflows.title'),
+        label: this.translocoService.translate('menu.workflows.title'),
         icon: 'pi pi-fw pi-book',
         items: [
-          {label: this.translocoService.translate('app.menu.workflows.create_invoice'), icon: 'pi pi-fw pi-plus', routerLink: '/workflow-create-invoice'},
+          {label: this.translocoService.translate('menu.workflows.create_invoice'), icon: 'pi pi-fw pi-plus', routerLink: '/workflow-create-invoice'},
         ]
       },
       {
-        label: this.translocoService.translate('app.menu.logout'),
+        label: this.translocoService.translate('menu.logout'),
         icon: 'pi pi-fw pi-sign-out',
         command: () => this.appSecurityService.logout()
       }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/app.component.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/app.component.ts
@@ -4,6 +4,7 @@ import { Router } from "@angular/router";
 import { MenuItem } from "primeng/api";
 import { Menu } from "primeng/menu";
 import { isAuthenticated } from "./common-services/common-services-util.service";
+import { TranslocoService } from "@jsverse/transloco";
 
 @Component({
   selector: 'app-root',
@@ -20,7 +21,7 @@ export class AppComponent implements OnInit, AfterViewInit {
   protected readonly isAuthenticated = isAuthenticated;
   notLoaded: boolean = true;
 
-  constructor(public appSecurityService: AppSecurityService, public router: Router) {
+  constructor(public appSecurityService: AppSecurityService, public router: Router, private translocoService: TranslocoService) {
 
   }
 
@@ -28,40 +29,40 @@ export class AppComponent implements OnInit, AfterViewInit {
 
     this.menuItems = [
       {
-        label: 'User management',
+        label: this.translocoService.translate('app.menu.user_management'),
         icon: 'pi pi-fw pi-users',
         items: [
-          {label: 'Create user', icon: 'pi pi-fw pi-user-plus', routerLink: '/user-registration-page'}
+          {label: this.translocoService.translate('app.menu.create_user'), icon: 'pi pi-fw pi-user-plus', routerLink: '/user-registration-page'}
         ]
       },
       {
-        label: 'Invoice',
+        label: this.translocoService.translate('app.menu.invoice.title'),
         icon: 'pi pi-fw pi-book',
         items: [
-          {label: 'Create invoice', icon: 'pi pi-fw pi-plus', routerLink: '/create-invoice-page'},
-          {label: 'Create catalog item', icon: 'pi pi-fw pi-plus', routerLink: '/create-invoice-item-page'},
-          {label: 'Manage catalog items', icon: 'pi pi-fw pi-pencil', routerLink: '/catalog-item-management-page'},
-          {label: 'Invoice management', icon: 'pi pi-fw pi-pencil', routerLink: '/invoice-management_page'},
-          {label: 'Print invoice', icon: 'pi pi-fw pi-file-pdf', routerLink: '/invoice-list_page'}
+          {label: this.translocoService.translate('app.menu.invoice.create'), icon: 'pi pi-fw pi-plus', routerLink: '/create-invoice-page'},
+          {label: this.translocoService.translate('app.menu.invoice.create_catalog_item'), icon: 'pi pi-fw pi-plus', routerLink: '/create-invoice-item-page'},
+          {label: this.translocoService.translate('app.menu.invoice.manage_catalog_items'), icon: 'pi pi-fw pi-pencil', routerLink: '/catalog-item-management-page'},
+          {label: this.translocoService.translate('app.menu.invoice.management'), icon: 'pi pi-fw pi-pencil', routerLink: '/invoice-management_page'},
+          {label: this.translocoService.translate('app.menu.invoice.print'), icon: 'pi pi-fw pi-file-pdf', routerLink: '/invoice-list_page'}
         ]
       },
       {
-        label: 'Person',
+        label: this.translocoService.translate('app.menu.person.title'),
         icon: 'pi pi-fw pi-user',
         items: [
-          {label: 'Create Peron', icon: 'pi pi-fw pi-plus', routerLink: '/create-person_page'},
-          {label: 'Person management', icon: 'pi pi-fw pi-pencil', routerLink: '/person-management-page'}
+          {label: this.translocoService.translate('app.menu.person.create'), icon: 'pi pi-fw pi-plus', routerLink: '/create-person_page'},
+          {label: this.translocoService.translate('app.menu.person.management'), icon: 'pi pi-fw pi-pencil', routerLink: '/person-management-page'}
         ]
       },
       {
-        label: 'Workflows',
+        label: this.translocoService.translate('app.menu.workflows.title'),
         icon: 'pi pi-fw pi-book',
         items: [
-          {label: 'Create invoice', icon: 'pi pi-fw pi-plus', routerLink: '/workflow-create-invoice'},
+          {label: this.translocoService.translate('app.menu.workflows.create_invoice'), icon: 'pi pi-fw pi-plus', routerLink: '/workflow-create-invoice'},
         ]
       },
       {
-        label: 'Logout',
+        label: this.translocoService.translate('app.menu.logout'),
         icon: 'pi pi-fw pi-sign-out',
         command: () => this.appSecurityService.logout()
       }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/app.component.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/app.component.ts
@@ -1,10 +1,11 @@
-import {AfterViewInit, Component, OnInit, ViewChild} from '@angular/core';
+import {AfterViewInit, Component, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import { AppSecurityService } from './common-auth/app-security.service';
 import { Router } from "@angular/router";
 import { MenuItem } from "primeng/api";
 import { Menu } from "primeng/menu";
-import { isAuthenticated } from "./common-services/common-services-util.service";
-import { TranslocoService } from "@jsverse/transloco";
+import {isAuthenticated, printToJson} from "./common-services/common-services-util.service";
+import {TranslocoService} from "@jsverse/transloco";
+import {Subject, takeUntil} from "rxjs";
 
 @Component({
   selector: 'app-root',
@@ -13,20 +14,25 @@ import { TranslocoService } from "@jsverse/transloco";
   providers: [AppSecurityService]
 })
 
-export class AppComponent implements OnInit, AfterViewInit {
+export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   title = 'frontend';
   menuItems: MenuItem[];
   @ViewChild('bigMenu') bigMenu: Menu;
   @ViewChild('smallMenu') smallMenu: Menu;
   protected readonly isAuthenticated = isAuthenticated;
   notLoaded: boolean = true;
+  private readonly destroy$ = new Subject<void>();
 
   constructor(public appSecurityService: AppSecurityService, public router: Router, private translocoService: TranslocoService) {
-
   }
 
-  ngOnInit(): void {
+  ngOnInit() {
+    this.translocoService.selectTranslation()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.buildMenuItems());
+  }
 
+  buildMenuItems(): void {
     this.menuItems = [
       {
         label: this.translocoService.translate('menu.user_management'),
@@ -72,5 +78,10 @@ export class AppComponent implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit(): void {
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/app.module.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/app.module.ts
@@ -50,6 +50,8 @@ import {
 } from "./common-components/validatable-input-text/validatable-input-text.component";
 import Lara from '@primeng/themes/lara';
 import {providePrimeNG} from "primeng/config";
+import { TranslocoModule } from '@jsverse/transloco';
+import { translocoProviders } from './transloco/transloco.providers';
 
 @NgModule({ bootstrap: [AppComponent],
     declarations: [
@@ -92,7 +94,8 @@ import {providePrimeNG} from "primeng/config";
         ReactiveFormsModule,
         TemplatesComponentComponent,
         StoreModule.forRoot({}),
-        ValidatableInputTextComponent],
+        ValidatableInputTextComponent,
+        TranslocoModule],
         providers:
           [
             providePrimeNG({
@@ -104,6 +107,7 @@ import {providePrimeNG} from "primeng/config";
             CommonServicesUtilService,
             MessageService,
             InvoiceItemsTableCalculatorService,
+            ...translocoProviders,
         { provide: HTTP_INTERCEPTORS, useClass: BasicInterceptor, multi: true }, HttpClient, provideHttpClient(withInterceptorsFromDi())] })
 export class AppModule {
 }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/confirmation-dialog/confirmation-dialog.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/confirmation-dialog/confirmation-dialog.component.html
@@ -18,12 +18,12 @@
     <div class="p-grid p-justify-end p-ai-center dialog-footer">
       <div class="p-col-12 p-md-3">
         <button (click)="onConfirm()" class="p-button-danger w-100" pButton type="button">
-          <span pButtonLabel>Yes</span>
+          <span pButtonLabel>{{ 'common.dialog.confirm.yes' | transloco }}</span>
         </button>
       </div>
       <div class="p-col-12 p-md-3">
         <button (click)="onCancel()" class="p-button-secondary w-100" pButton type="button">
-          <span pButtonLabel>No</span>
+          <span pButtonLabel>{{ 'common.dialog.confirm.no' | transloco }}</span>
         </button>
       </div>
     </div>

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/confirmation-dialog/confirmation-dialog.component.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/confirmation-dialog/confirmation-dialog.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { DialogModule } from "primeng/dialog";
 import { ButtonModule } from "primeng/button";
+import { TranslocoModule } from '@jsverse/transloco';
 
 @Component({
   selector: 'app-confirmation-dialog',
@@ -9,7 +10,8 @@ import { ButtonModule } from "primeng/button";
   imports: [
     CommonModule,
     DialogModule,
-    ButtonModule
+    ButtonModule,
+    TranslocoModule
   ],
   templateUrl: './confirmation-dialog.component.html',
   styleUrls: ['./confirmation-dialog.component.css']

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/dateperiod-finder/dateperiod-finder.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/dateperiod-finder/dateperiod-finder.component.html
@@ -4,14 +4,14 @@
     <div *ngIf="service.processRuns" class="overlayProcess childElementCenter">
       <mat-progress-spinner *ngIf="service.processRuns" mode="indeterminate"></mat-progress-spinner>
     </div>
-    <h3 style="margin-left: 5pt">Select date period</h3>
+    <h3 style="margin-left: 5pt">{{ 'common.datePeriod.title' | transloco }}</h3>
     <div class="p-grid">
 
       <div class="p-col-3 justifyPanel">
         <app-validatable-calendar (controlModel)="startDateControlModel = $event"
                                   [(ngModel)]="requestDatePeriod.startDate"
                                   [idComponent]="'id-StartDate'"
-                                  [labelText]="'Start Date'"
+                                  [labelText]="'common.datePeriod.startDate' | transloco"
                                   [name]="'startDate'"
                                   calendarDateFormat="dd.mm.yy">
         </app-validatable-calendar>
@@ -21,14 +21,14 @@
         <app-validatable-calendar (controlModel)="endDateControlModel = $event"
                                   [(ngModel)]="requestDatePeriod.endDate"
                                   [idComponent]="'id-EndDate'"
-                                  [labelText]="'End Date'"
+                                  [labelText]="'common.datePeriod.endDate' | transloco"
                                   [name]="'endDate'"
                                   calendarDateFormat="dd.mm.yy">
         </app-validatable-calendar>
       </div>
 
       <div class="p-col-1 justifyPanel">
-        <p-button [disabled]="isSubmitButtonDisabled()" icon="pi pi-check" label="Find"
+        <p-button [disabled]="isSubmitButtonDisabled()" icon="pi pi-check" [label]="'common.actions.find' | transloco"
                   styleClass="p-button-text submit-button" type="submit"></p-button>
       </div>
 

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/dateperiod-finder/dateperiod-finder.component.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/dateperiod-finder/dateperiod-finder.component.ts
@@ -8,11 +8,12 @@ import { ButtonModule } from "primeng/button";
 import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
 import { ToastModule } from "primeng/toast";
 import { MessageModule } from "primeng/message";
+import { TranslocoModule } from '@jsverse/transloco';
 
 @Component({
   selector: 'app-dateperiod-finder',
   standalone: true,
-  imports: [CommonModule, ValidatableCalendarModule, FormsModule, ButtonModule, MatProgressSpinnerModule, ToastModule, MessageModule],
+  imports: [CommonModule, ValidatableCalendarModule, FormsModule, ButtonModule, MatProgressSpinnerModule, ToastModule, MessageModule, TranslocoModule],
   templateUrl: './dateperiod-finder.component.html',
   styleUrls: ['./dateperiod-finder.component.css']
 })

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/validatable-calendar/validatable-calendar.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/validatable-calendar/validatable-calendar.component.html
@@ -50,10 +50,10 @@
       modelCalendarRef.errors?.['required']
     ) && (modelCalendarRef.dirty || modelCalendarRef.touched)
     ) {
-    <small class="validation-text">Date is required</small>
+    <small class="validation-text">{{ 'common.validation.date_required' | transloco }}</small>
   }
 
   @if (modelCalendarRef.errors?.['startDateMoreEndDate']) {
-    <small class="validation-text">Start date must be before end date</small>
+    <small class="validation-text">{{ 'common.validation.start_before_end' | transloco }}</small>
   }
 </div>

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/validatable-calendar/validatable-calendar.component.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/validatable-calendar/validatable-calendar.component.ts
@@ -16,6 +16,7 @@ import { MessageModule } from 'primeng/message';
 import { ToastModule } from 'primeng/toast';
 import { FloatLabel } from 'primeng/floatlabel';
 import { DatePickerModule } from 'primeng/datepicker';
+import { TranslocoModule } from '@jsverse/transloco';
 
 @Component({
   selector: 'app-validatable-calendar',
@@ -118,7 +119,8 @@ export class ValidatableCalendarComponent implements OnInit, ControlValueAccesso
     FormsModule,
     ToastModule,
     DatePickerModule,
-    FloatLabel
+    FloatLabel,
+    TranslocoModule
   ],
   declarations: [ValidatableCalendarComponent],
   exports: [ValidatableCalendarComponent]

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/validatable-dropdownlist/validatable-dropdownlist.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/validatable-dropdownlist/validatable-dropdownlist.component.html
@@ -27,7 +27,7 @@
   @if (setHasMinLengthError(modelRef.errors?.['minlength'] !== null,
     modelRef.errors?.['minlength']) && (modelRef.dirty || modelRef.touched)) {
     <div class="error-icon-box">
-      <small class="validation-text">Field is required.</small>
+      <small class="validation-text">{{ 'common.validation.required' | transloco }}</small>
     </div>
 
   }
@@ -35,7 +35,7 @@
     modelRef.errors?.['required'] !== null,
     modelRef.errors?.['required']) && (modelRef.dirty || modelRef.touched)) {
     <div class="error-icon-box">
-      <small class="validation-text">Field is required.</small>
+      <small class="validation-text">{{ 'common.validation.required' | transloco }}</small>
     </div>
   }
 

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/validatable-dropdownlist/validatable-dropdownlist.component.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/validatable-dropdownlist/validatable-dropdownlist.component.ts
@@ -49,6 +49,7 @@ import { MessageModule } from "primeng/message";
 import { ToastModule } from "primeng/toast";
 import { DropdownModule } from "primeng/dropdown";
 import {FloatLabel} from "primeng/floatlabel";
+import { TranslocoModule } from '@jsverse/transloco';
 
 @Component({
   selector: 'app-validatable-dropdownlist',
@@ -154,7 +155,7 @@ export class ValidatableDropdownlistComponent implements OnInit, ControlValueAcc
 
 @NgModule(
   {
-    imports: [CommonModule, MessagesModule, MessageModule, FormsModule, ToastModule, DropdownModule, FloatLabel],
+    imports: [CommonModule, MessagesModule, MessageModule, FormsModule, ToastModule, DropdownModule, FloatLabel, TranslocoModule],
     declarations: [ValidatableDropdownlistComponent],
     exports: [ValidatableDropdownlistComponent],
     schemas: [CUSTOM_ELEMENTS_SCHEMA]

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/validatable-input-text/validatable-input-text.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/validatable-input-text/validatable-input-text.component.html
@@ -41,7 +41,7 @@
   @if (setHasMinLengthError(modelRef.errors?.['minlength'] !== null, modelRef.errors?.['minlength'])) {
     <div class = "error-message-cmp">
           <small class="validation-text">
-            {{ 'common.validation.min_length' | transloco: { min: txtMinLength } }}
+            {{ 'validation.min_length' | transloco: { min: txtMinLength } }}
           </small>
     </div>
   }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/validatable-input-text/validatable-input-text.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/validatable-input-text/validatable-input-text.component.html
@@ -35,13 +35,13 @@
   </div>
   @if (setHasRequiredError(modelRef.errors?.['required'] !== undefined &&
     modelRef.errors?.['required'] !== null, modelRef.errors?.['required']) && (modelRef.dirty || modelRef.touched)) {
-    <small class="validation-text">Field is required.</small>
+    <small class="validation-text">{{ 'common.validation.required' | transloco }}</small>
   }
 
   @if (setHasMinLengthError(modelRef.errors?.['minlength'] !== null, modelRef.errors?.['minlength'])) {
     <div class = "error-message-cmp">
           <small class="validation-text">
-            Minimum length is {{ txtMinLength }}.
+            {{ 'common.validation.min_length' | transloco: { min: txtMinLength } }}
           </small>
     </div>
   }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/validatable-input-text/validatable-input-text.component.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/common-components/validatable-input-text/validatable-input-text.component.ts
@@ -48,6 +48,7 @@ import { MessageModule } from "primeng/message";
 import { ToastModule } from "primeng/toast";
 import { InputTextModule } from "primeng/inputtext";
 import { FloatLabelModule } from 'primeng/floatlabel';
+import { TranslocoModule } from '@jsverse/transloco';
 
 
 
@@ -63,7 +64,7 @@ import { FloatLabelModule } from 'primeng/floatlabel';
       multi: true
     }
   ],
-  imports: [CommonModule, MessagesModule, MessageModule, FormsModule, ToastModule, InputTextModule, FloatLabelModule],
+  imports: [CommonModule, MessagesModule, MessageModule, FormsModule, ToastModule, InputTextModule, FloatLabelModule, TranslocoModule],
   schemas: [CUSTOM_ELEMENTS_SCHEMA]
 
 })

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/edit-invoice-dialog/edit-invoice-dialog.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/edit-invoice-dialog/edit-invoice-dialog.component.html
@@ -34,7 +34,7 @@
             <ng-container *ngTemplateOutlet="templatesComponent.inputTextTemplate;
           context:{controlPath: 'invoiceNumber',
                    idComponent: 'id_InvoiceNumber',
-                   labelText: 'Invoice Number'
+                   labelText: 'invoice.invoice_number' | transloco
                   }">
             </ng-container>
           </div>
@@ -42,7 +42,7 @@
             <ng-container *ngTemplateOutlet="templatesComponent.inputTextTemplate;
           context:{controlPath: 'invoiceDescription',
                    idComponent: 'id-invoiceDescription',
-                   labelText: 'Invoice description'
+                   labelText: 'invoice.description' | transloco
                   }">
             </ng-container>
           </div>
@@ -54,7 +54,7 @@
           context:{controlPath: 'rateType',
                    placeholderPar: 'Select rate Type',
                    idComponent: 'id-rateType',
-                   labelText: 'Rate Type',
+                   labelText: 'invoice.rate_type' | transloco,
                    optionList: invoiceRate
                   }">
             </ng-container>
@@ -65,7 +65,7 @@
             <ng-container *ngTemplateOutlet="templatesComponent.calendarTemplate;
           context:{controlPath: 'invoiceDate',
                    idComponent: 'id-InvoiceDate',
-                   labelText: 'Invoice Date',
+                   labelText: 'invoice.invoice_date' | transloco,
                    calendarDateFormat: 'dd.mm.yy'
                   }">
             </ng-container>
@@ -76,7 +76,7 @@
             <ng-container *ngTemplateOutlet="templatesComponent.calendarTemplate;
           context:{controlPath: 'creationDate',
                    idComponent: 'id-creationDate',
-                   labelText: 'Creation Date',
+                   labelText: 'invoice.creation_date' | transloco,
                    calendarDateFormat: 'dd.mm.yy'
                   }">
             </ng-container>
@@ -89,7 +89,7 @@
           context:{controlPath: 'personSupplierId',
                    placeholderPar: 'Select person',
                    idComponent: 'id-invoiceCreator',
-                   labelText: 'Invoice creator person',
+                   labelText: 'invoice.person_creator' | transloco,
                    optionList: personInvoiceSupplier
                   }">
             </ng-container>
@@ -102,7 +102,7 @@
           context:{controlPath: 'personRecipientId',
                    placeholderPar: 'Select person',
                    idComponent: 'id-invoiceCreator',
-                   labelText: 'Invoice recipient person',
+                   labelText: 'invoice.person_recipient' | transloco,
                    optionList: personInvoiceRecipient
                   }">
             </ng-container>
@@ -123,9 +123,9 @@
     </div>
   </div>
   <ng-template pTemplate="footer">
-    <p-button (click)="putChangesBack()" [disabled]="haveErrors()" icon="pi pi-check" label="Save"
+    <p-button (click)="putChangesBack()" [disabled]="haveErrors()" icon="pi pi-check" label="{{'common.actions.save' | transloco}}"
               styleClass="p-button-text"></p-button>
-    <p-button (click)="setVisible(false)" icon="pi pi-check pink-300" label="Cancel"
+    <p-button (click)="setVisible(false)" icon="pi pi-check pink-300" label="{{'common.actions.cancel' | transloco}}"
               styleClass="p-button-text p-button-secondary"></p-button>
   </ng-template>
 </p-dialog>

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/edit-invoice-dialog/edit-invoice-dialog.component.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/edit-invoice-dialog/edit-invoice-dialog.component.ts
@@ -48,6 +48,7 @@ import { MessageModule } from "primeng/message";
 import { MessagesModule } from "primeng/messages";
 import { ConfirmationDialogComponent } from "../../common-components/confirmation-dialog/confirmation-dialog.component";
 import {InvoiceItemsTableCalculatorService} from "../invoice-items-table/invoice-items-table.calculator.service";
+import {TranslocoPipe} from "@jsverse/transloco";
 
 export type InvoiceControls = { [key in keyof InvoiceFormModelInterface]: AbstractControl }
 type InvoiceFormGroup = FormGroup & { value: InvoiceFormModelInterface, controls: InvoiceControls }
@@ -66,7 +67,7 @@ type InvoiceFormGroup = FormGroup & { value: InvoiceFormModelInterface, controls
     ValidatableDropdownlistModule,
     TemplatesComponentComponent,
     TooltipModule, MessageModule, MessagesModule,
-    DialogModule, CalendarModule, InvoiceReactiveItemsTableComponent, ConfirmationDialogComponent],
+    DialogModule, CalendarModule, InvoiceReactiveItemsTableComponent, ConfirmationDialogComponent, TranslocoPipe],
   providers: [
     MessageService, MessagesPrinter, CommonServicesUtilService
   ],

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/invoice-items-table/invoice-items-table.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/invoice-items-table/invoice-items-table.component.html
@@ -14,13 +14,13 @@
                  sortMode="multiple" styleClass="p-datatable-gridlines">
           <ng-template pTemplate="header">
             <tr>
-              <th style="width: 40%">Item description</th>
-              <th style="width: 10%">Amount</th>
-              <th style="width: 10%">Price</th>
-              <th style="width: 10%">Vat%</th>
-              <th style="width: 10%">Sum netto</th>
-              <th style="width: 10%">Sum brutto</th>
-              <th style="width: 10%">Manage</th>
+              <th style="width: 40%">{{'invoice.item.table.short_description' | transloco}}</th>
+              <th style="width: 10%">{{'invoice.item.table.amount' | transloco}}</th>
+              <th style="width: 10%">{{'invoice.item.table.price' | transloco}}</th>
+              <th style="width: 10%">{{'invoice.item.table.vat' | transloco}}</th>
+              <th style="width: 10%">{{'invoice.item.table.sum_netto' | transloco}}</th>
+              <th style="width: 10%">{{'invoice.item.table.sum_brutto' | transloco}}</th>
+              <th style="width: 10%">{{'common.table.manage' | transloco}}</th>
             </tr>
           </ng-template>
           <ng-template let-invoiceitem pTemplate="body">
@@ -141,7 +141,7 @@
       </div>
       <div class="p-col-12" style="background-color: white">
         <div class="add-button-container-size" style="display: block; background-color: white">
-          <p-button (onClick)="addNewItem()" [pTooltip]="'Add new empty item'" label="Add item"
+          <p-button (onClick)="addNewItem()" [pTooltip]="'Add new empty item'" label="{{'invoice.add_item' | transloco}}"
                     styleClass="p-button-secondary"></p-button>
         </div>
       </div>
@@ -152,7 +152,7 @@
       <div class="p-col-10"></div>
       <div class="p-col-2" style="padding-top: 0pt !important; padding-bottom: 0pt !important;">
 
-        <label for="id-tottalNettoSun" style="margin: 5px">Total netto</label>
+        <label for="id-tottalNettoSun" style="margin: 5px">{{'invoice.total_netto' | transloco}}</label>
         <input [ngModel]="calculatorService.totalNettoSum()  | standardFloat"
                class="p-field" id="id-tottalNettoSun" name="totalNettoSum" placeholder="0.00"
                readonly
@@ -164,7 +164,7 @@
     <div class="p-grid">
       <div class="p-col-10" style="padding-top: 0 !important; padding-bottom: 0 !important;"></div>
       <div class="p-col-2" style="padding-top: 0 !important; padding-bottom: 0 !important;">
-        <label for="id-tottalBruttoSun" style="margin: 5px">Total brutto</label>
+        <label for="id-tottalBruttoSun" style="margin: 5px">{{'invoice.total_brutto' | transloco}}</label>
         <input [ngModel]="calculatorService.totalBruttoSum() | standardFloat"
                class="p-cell-editing" id="id-tottalBruttoSun" name="totalBruttoSum"
                placeholder="0.00"

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/invoice-management/invoice-management.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/invoice-management/invoice-management.component.html
@@ -48,7 +48,7 @@
             <tr (dblclick)="rowDoubleClick($event, invoice)" [ngStyle]="{'color':isEditObjectChanged(invoice)}"
                 [pSelectableRowIndex]="rowIndex"
                 [pSelectableRow]="invoice"
-                title="{{ 'invoice.management.tooltips.edit_invoice' | transloco }}">
+                title="{{ 'management.tooltips.edit_invoice' | transloco }}">
               <td>
                 <div>{{invoice.invoiceNumber}}</div>
               </td>
@@ -99,7 +99,7 @@
     <div class="p-col-12 save-button-col-size">
       <div class="save-button-container-size">
         <p-button (onClick)="showSaveConfirmDialog = true" [disabled]="haveNoChanges()"
-                  [label]="'common.actions.save' | transloco"></p-button>
+                  [label]="'actions.save' | transloco"></p-button>
       </div>
     </div>
   </div>
@@ -109,7 +109,7 @@
                            (editObjectChangedChanged)="putEditDialogChanges($event)"></app-edit-invoice-dialog>
 
   <app-confirmation-dialog #confirmDeleteInvoiceDialog
-                           [confirmMessage]="'invoice.management.confirm.delete' | transloco"
+                           [confirmMessage]="'management.confirm.delete' | transloco"
                            (canceled)="handleCancelDeleteInvoice($event)"
                            (confirmed)="handleConfirmationDeleteInvoice(confirmDeleteInvoiceDialog.transferObject)"
                            [display]="showDeleteConfirmDialog"

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/invoice-management/invoice-management.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/invoice-management/invoice-management.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="isAuthenticated();" class="p-fluid p-flex-row management-page-style">
   <p-toast></p-toast>
   <div class="p-grid base-top-grid-area">
-    <H2 style="margin-left: 10pt;">Invoice management</H2>
+    <H2 style="margin-left: 10pt;">{{ 'invoice.management.title' | transloco }}</H2>
     <div class="p-col-12" style="height: 15%">
       <app-dateperiod-finder #dataFinder (onFinderIsReady)="finderIsReady($event)"
                              (responseOutput)="invoices = $event" [url]="'invoice/invoicesListPeriod'"/>
@@ -20,35 +20,35 @@
                  sortMode="multiple" styleClass="p-datatable-gridlines">
           <ng-template pTemplate="header">
             <tr>
-              <th pSortableColumn="invoiceNumber" style="width: 10%">Invoice number
+              <th pSortableColumn="invoiceNumber" style="width: 10%">{{ 'invoice.management.table.invoice_number' | transloco }}
                 <p-sortIcon field="invoiceNumber"></p-sortIcon>
               </th>
-              <th pSortableColumn="supplierFullName" style="width: 25%">Supplier
+              <th pSortableColumn="supplierFullName" style="width: 25%">{{ 'invoice.management.table.supplier' | transloco }}
                 <p-sortIcon field="supplierFullName"></p-sortIcon>
               </th>
-              <th pSortableColumn="recipientFullName" style="width: 25%">Recipient
+              <th pSortableColumn="recipientFullName" style="width: 25%">{{ 'invoice.management.table.recipient' | transloco }}
                 <p-sortIcon field="recipientFullName"></p-sortIcon>
               </th>
-              <th pSortableColumn="invoiceDate" style="width: 10%">Invoice date
+              <th pSortableColumn="invoiceDate" style="width: 10%">{{ 'invoice.management.table.invoice_date' | transloco }}
                 <p-sortIcon field="invoiceDate"></p-sortIcon>
               </th>
-              <th pSortableColumn="creationDate" style="width: 10%">Invoice creation date
+              <th pSortableColumn="creationDate" style="width: 10%">{{ 'invoice.management.table.creation_date' | transloco }}
                 <p-sortIcon field="creationDate"></p-sortIcon>
               </th>
-              <th pSortableColumn="totalSumNetto" style="width: 10%">Netto sum
+              <th pSortableColumn="totalSumNetto" style="width: 10%">{{ 'invoice.management.table.netto_sum' | transloco }}
                 <p-sortIcon field="totalSumNetto"></p-sortIcon>
               </th>
-              <th pSortableColumn="totalSumBrutto" style="width: 10%">Brutto sum
+              <th pSortableColumn="totalSumBrutto" style="width: 10%">{{ 'invoice.management.table.brutto_sum' | transloco }}
                 <p-sortIcon field="totalSumBrutto"></p-sortIcon>
               </th>
-              <th style="width: 5%">Manage</th>
+              <th style="width: 5%">{{ 'common.table.manage' | transloco }}</th>
             </tr>
           </ng-template>
           <ng-template let-invoice let-rowIndex="rowIndex" pTemplate="body">
             <tr (dblclick)="rowDoubleClick($event, invoice)" [ngStyle]="{'color':isEditObjectChanged(invoice)}"
                 [pSelectableRowIndex]="rowIndex"
                 [pSelectableRow]="invoice"
-                title="Double click to edit person">
+                title="{{ 'invoice.management.tooltips.edit_invoice' | transloco }}">
               <td>
                 <div>{{invoice.invoiceNumber}}</div>
               </td>
@@ -74,19 +74,19 @@
               <td>
                 <button (click)="deleteInvoice(invoice.id)" class="p-button-rounded p-button-warning"
                         pButton pRipple
-                        title="Delete item">
+                        title="{{ 'common.tooltips.delete_item' | transloco }}">
                   <i class="pi pi-trash"></i>
                 </button>
                 <button (click)="rowDoubleClick($event, invoice)" class="p-button-rounded p-button-warning undo-button"
                         pButton pRipple
-                        title="Edit item">
+                        title="{{ 'common.tooltips.edit_item' | transloco }}">
                   <i class="pi pi-pencil"></i>
                 </button>
                 <button (click)="rollbackChanges(invoice.id)" class="p-button-rounded p-button-warning undo-button"
                         pButton
                         style=""
                         pRipple
-                        title="Rollback item">
+                        title="{{ 'common.tooltips.rollback_item' | transloco }}">
                            <i class="pi pi-undo"></i>
                 </button>
               </td>
@@ -99,7 +99,7 @@
     <div class="p-col-12 save-button-col-size">
       <div class="save-button-container-size">
         <p-button (onClick)="showSaveConfirmDialog = true" [disabled]="haveNoChanges()"
-                  label="Save"></p-button>
+                  [label]="'common.actions.save' | transloco"></p-button>
       </div>
     </div>
   </div>
@@ -109,7 +109,7 @@
                            (editObjectChangedChanged)="putEditDialogChanges($event)"></app-edit-invoice-dialog>
 
   <app-confirmation-dialog #confirmDeleteInvoiceDialog
-                           [confirmMessage]="'Confirm delete invoice'"
+                           [confirmMessage]="'invoice.management.confirm.delete' | transloco"
                            (canceled)="handleCancelDeleteInvoice($event)"
                            (confirmed)="handleConfirmationDeleteInvoice(confirmDeleteInvoiceDialog.transferObject)"
                            [display]="showDeleteConfirmDialog"

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/invoice-management/invoice-management.component.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/invoice-management/invoice-management.component.ts
@@ -24,6 +24,7 @@ import {isAuthenticated, printToJson} from "../../common-services/common-service
 import { CommonServicesEditService } from "../../common-services/common-services.edit.service";
 import { environment } from "../../../environments/environment";
 import { CommonServiceEventListener } from "../../common-services/common-service.event.bus";
+import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 
 @NgModule(
   {
@@ -40,7 +41,7 @@ export class InvoiceManagementModule {
   imports: [CommonModule, MatProgressSpinnerModule, SharedModule, FormsModule, TableModule, ToastModule,
     InvoiceManagementModule, ValidatableCalendarModule, DateperiodFinderComponent, InvoicePipesModule,
     ButtonModule, RippleModule, EditInvoiceDialogComponent, CalendarModule, ConfirmationDialogComponent,
-    MessageModule, MessagesModule],
+    MessageModule, MessagesModule, TranslocoModule],
   templateUrl: './invoice-management.component.html',
   styleUrls: ['./invoice-management.component.css'],
   providers: [CommonServicesPipesDate, AppSecurityService, MessagesPrinter]
@@ -54,18 +55,19 @@ export class InvoiceManagementComponent extends CommonServicesEditService<Invoic
 
   keySelection: boolean = true;
   selectedInvoice!: InvoiceFormModel;
-  deleteConfirmDialogMessage: any = 'Are you really want to permanently delete invoice?'
+  deleteConfirmDialogMessage: any = ''
   showDeleteConfirmDialog: boolean = false
   showSaveConfirmDialog: boolean = false
 
   //invoiceChangesList: InvoiceFormModel[] = []
-  saveConfirmDialogMessage: string = 'Are you really want to permanently save changes in invoices'
+  saveConfirmDialogMessage: string = ''
   protected readonly Date = Date;
   protected readonly isAuthenticated = isAuthenticated;
   eventBusVal: any
 
   constructor(public securityService: AppSecurityService,
-              private httpService: CommonServicesAppHttpService<any>, private messagePrinter: MessagesPrinter, private eventListener: CommonServiceEventListener<any>) {
+              private httpService: CommonServicesAppHttpService<any>, private messagePrinter: MessagesPrinter, private eventListener: CommonServiceEventListener<any>,
+              private translocoService: TranslocoService) {
     super(httpService.httpClient, 'Can not load items catalog by criteria: ', 'invoice/itemsCatalogList')
     if (environment.debugMode) {
        of(eventListener).subscribe(l =>this.eventBusVal=l.busEvent);
@@ -91,6 +93,8 @@ export class InvoiceManagementComponent extends CommonServicesEditService<Invoic
   }
 
   ngOnInit(): void {
+    this.deleteConfirmDialogMessage = this.translocoService.translate('invoice.management.confirm.delete_message')
+    this.saveConfirmDialogMessage = this.translocoService.translate('invoice.management.confirm.save_message')
     setTimeout(() => {
       of(this.dataFinder).subscribe(f => f.loadData())
     })

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/invoice-reactive-items-table/invoice-reactive-items-table.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/invoice-reactive-items-table/invoice-reactive-items-table.component.html
@@ -111,7 +111,7 @@
 
   <div class="p-col-12" style="display: block">
     <p-button (onClick)="addNewItem()" [pTooltip]="'Add new empty item'" class="p-button-secondary save-button-style"
-              label="Add item"></p-button>
+              label="{{'invoice.add_item' | transloco}}"></p-button>
   </div>
 
 </div>

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/invoice-reactive-items-table/invoice-reactive-items-table.component.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/invoice-reactive-items-table/invoice-reactive-items-table.component.ts
@@ -44,6 +44,7 @@ import { ConfirmationDialogComponent } from "../../common-components/confirmatio
 import { HttpClient } from "@angular/common/http";
 import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 import {InputNumber} from "primeng/inputnumber";
+import {TranslocoPipe} from "@jsverse/transloco";
 
 @Component({
   styles: [],
@@ -62,7 +63,8 @@ import {InputNumber} from "primeng/inputnumber";
     TooltipModule,
     ToastModule,
     ConfirmationDialogComponent,
-    InputNumber
+    InputNumber,
+    TranslocoPipe
   ],
   providers: [HttpClient]
 })

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/invoiceform/invoiceform.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/invoiceform/invoiceform.component.html
@@ -11,7 +11,7 @@
         <app-validatable-input-text (componentHasErrorEvent)="setHasInvoiceNumberError($event)"
                                     [(ngModel)]="invoiceFormData.invoiceNumber"
                                     [idComponent]="'id_InvoiceNumber'"
-                                    [labelText]="'Invoice Number'"
+                                    [labelText]="'invoice.number' | transloco"
                                     [name]="'invoiceNumber'"
                                     [txtMinLength]="5">
         </app-validatable-input-text>
@@ -21,7 +21,7 @@
          <input [(ngModel)]="invoiceFormData.invoiceDescription" id="id-invoiceDescription" name="'invoiceDescription'"
                 pInputText
                 style="width:100%;" type="text"/>
-         <label for="id-invoiceDescription">Invoice description</label>
+         <label for="id-invoiceDescription">{{'invoice.description' | transloco}}</label>
        </p-floatlabel>
       </div>
 
@@ -31,7 +31,7 @@
         <app-validatable-dropdownlist (componentHasError)="setHasInvoiceratesError($event)"
                                       [(ngModel)]="invoiceFormData.rateType"
                                       [idComponent]="'id-rateType'"
-                                      [labelText]="'Rate Type'"
+                                      [labelText]="'invoice.rate_type' | transloco"
                                       [name]="'invoiceRatesList'"
                                       [optionList]="invoiceRate"
                                       [txtMinLength]="1">
@@ -45,7 +45,7 @@
                                   [(ngModel)]="invoiceFormData.creationDate"
                                   [dateFormat]="'dd.mm.yy'"
                                   [idComponent]="'id-creationDate'"
-                                  [labelText]="'Creation Date'"
+                                  [labelText]="'invoice.creation_date' | transloco"
                                   [name]="'creationDate'"
                                   calendarDateFormat="dd.mm.yy"
                                   maxlength="10">
@@ -57,7 +57,7 @@
                                   [(ngModel)]="invoiceFormData.invoiceDate"
                                   [dateFormat]="'dd.mm.yy'"
                                   [idComponent]="'id-InvoiceDate'"
-                                  [labelText]="'Invoice Date'"
+                                  [labelText]="'invoice.invoice_date' | transloco"
                                   [name]="'invoiceDate'"
                                   calendarDateFormat="dd.mm.yy"
                                   maxlength="10">
@@ -70,7 +70,7 @@
         <app-validatable-dropdownlist (componentHasError)="setHasCreatorError($event)"
                                       [(ngModel)]="invoiceFormData.personSupplierId"
                                       [idComponent]="'id-invoiceCreator'"
-                                      [labelText]="'Invoice creator person'"
+                                      [labelText]="'invoice.person_creator' | transloco"
                                       [name]="'creator'"
                                       [optionList]="personInvoiceSupplier"
                                       [placeholder]="'Select person'"
@@ -84,7 +84,7 @@
         <app-validatable-dropdownlist (componentHasError)="setHasRecipientError($event)"
                                       [(ngModel)]="invoiceFormData.personRecipientId"
                                       [idComponent]="'id-invoiceRecipient'"
-                                      [labelText]="'Invoice recipient person'"
+                                      [labelText]="'invoice.person_recipient' | transloco"
                                       [name]="'recipient'"
                                       [optionList]="personInvoiceRecipient"
                                       [placeholder]="'Select person'"

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/invoiceform/invoiceform.component.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/invoiceform/invoiceform.component.ts
@@ -73,6 +73,7 @@ import {
   ValidatableInputTextComponent
 } from "../../common-components/validatable-input-text/validatable-input-text.component";
 import {FloatLabel} from "primeng/floatlabel";
+import {TranslocoPipe} from "@jsverse/transloco";
 
 
 registerLocaleData(localede, 'de');
@@ -204,7 +205,7 @@ export class InvoiceFormComponent extends InvoiceFormValidator implements OnInit
     exports: [InvoiceFormComponent, InvoiceItemsTableComponent],
     imports: [CommonModule, FormsModule, ValidatableDropdownlistModule,
       ValidatableCalendarModule, InputTextModule, MessageModule, ToastModule, MessagesModule,
-      ButtonModule, TableModule, TooltipModule, InvoicePipesModule, InputNumberModule, DropdownModule, RippleModule, ValidatableInputTextComponent, FloatLabel], providers: [provideHttpClient(withInterceptorsFromDi())] }
+      ButtonModule, TableModule, TooltipModule, InvoicePipesModule, InputNumberModule, DropdownModule, RippleModule, ValidatableInputTextComponent, FloatLabel, TranslocoPipe], providers: [provideHttpClient(withInterceptorsFromDi())] }
 )
 export class InvoiceFormModule {
 }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/item-management/item-management.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/item-management/item-management.component.html
@@ -5,72 +5,71 @@
     <mat-progress-spinner *ngIf="dataLoading" mode="indeterminate"></mat-progress-spinner>
   </div>
 
+<div class="p-grid base-top-grid-area">
+<h2 style="margin-left: 10pt">{{'invoice.item.manage.catalog_items' | transloco}}</h2>
 
-  <div class="p-grid base-top-grid-area">
-    <h2 style="margin-left: 10pt">Manage with catalog items</h2>
+<div class="p-col-12 shadow-panel-color p-shadow-4">
 
-    <div class="p-col-12 shadow-panel-color p-shadow-4">
+<div class="p-grid w-100" style="margin-right: 0pt">
+<div class="p-col-4">
+<p-floatlabel class="w-100">
+<input [(ngModel)]="criteria"
+      class="ng-dirty p-mr-2"
+      id="Id_Search_Item"
+      minlength="0"
+      pInputText
+      type="text"/>
+<label for="Id_Search_Item">Search criteria</label>
+</p-floatlabel>
+</div>
+<div class="p-col-1">
+<p-button (click)="getDataFromServer(criteria)" label="Find"
+         title="Search items by name and description">
 
-      <div class="p-grid w-100" style="margin-right: 0pt">
-        <div class="p-col-4">
-          <p-floatlabel class="w-100">
-          <input [(ngModel)]="criteria"
-                 class="ng-dirty p-mr-2"
-                 id="Id_Search_Item"
-                 minlength="0"
-                 pInputText
-                 type="text"/>
-          <label for="Id_Search_Item">Search criteria</label>
-          </p-floatlabel>
-        </div>
-        <div class="p-col-1">
-          <p-button (click)="getDataFromServer(criteria)" label="Find"
-                    title="Search items by name and description">
-
-          </p-button>
-        </div>
-      </div>
-    </div>
-    <div class="p-col-12 p-shadow-4 top-container-table-area">
-      <div class="table-area">
-        <p-table [(selection)]="selectedItem"
-                 [autoLayout]="true"
-                 [metaKeySelection]=keySelection
-                 [resizableColumns]="true"
-                 [rows]="15"
-                 [value]="modelList"
-                 editMode="row"
-                 paginator="true" selectionMode="multiple" sortMode="multiple" styleClass="p-datatable-gridlines">
-          <ng-template pTemplate="header">
-            <tr>
-              <th style="width: 40%">Item description</th>
-              <th style="width: 10%">Amount</th>
-              <th style="width: 10%">Price</th>
-              <th style="width: 10%">Vat%</th>
-              <th style="width: 10%">Sum netto</th>
-              <th style="width: 10%">Sum brutto</th>
-              <th style="width: 10%">Delete</th>
-            </tr>
-          </ng-template>
-          <ng-template pTemplate="header">
-            <tr>
-              <th pSortableColumn="description" style="width: 30%">Item name
-                <p-sortIcon field="invoiceNumber"></p-sortIcon>
-              </th>
-              <th pSortableColumn="shortDescription" style="width: 30%">Short description
-                <p-sortIcon field="supplierFullName"></p-sortIcon>
-              </th>
-              <th pSortableColumn="itemPrice" style="width: 25%">Item price
-                <p-sortIcon field="recipientFullName"></p-sortIcon>
-              </th>
-              <th pSortableColumn="vat" style="width: 15%">Vat%
-                <p-sortIcon field="invoiceDate"></p-sortIcon>
-              </th>
-              <th style="width: 5%">Manage</th>
-            </tr>
-          </ng-template>
-          <ng-template let-catalogitem let-rowIndex="rowIndex" pTemplate="body">
-            <tr (dblclick)="rowDoubleClick($event, catalogitem)" [ngStyle]="{'color':isEditObjectChanged(catalogitem)}"
+</p-button>
+</div>
+</div>
+</div>
+<div class="p-col-12 p-shadow-4 top-container-table-area">
+<div class="table-area">
+<p-table [(selection)]="selectedItem"
+      [autoLayout]="true"
+      [metaKeySelection]=keySelection
+      [resizableColumns]="true"
+      [rows]="15"
+      [value]="modelList"
+      editMode="row"
+      paginator="true" selectionMode="multiple" sortMode="multiple" styleClass="p-datatable-gridlines">
+<ng-template pTemplate="header">
+ <tr>
+   <th style="width: 40%">{{'invoice.item.table.short_description' | transloco}}</th>
+   <th style="width: 10%">Amount</th>
+   <th style="width: 10%">{{'invoice.item.table.price' | transloco}}</th>
+   <th style="width: 10%">{{'invoice.item.table.vat' | transloco}}</th>
+   <th style="width: 10%">Sum netto</th>
+   <th style="width: 10%">Sum brutto</th>
+   <th style="width: 10%">Delete</th>
+ </tr>
+</ng-template>
+<ng-template pTemplate="header">
+ <tr>
+   <th pSortableColumn="description" style="width: 30%">{{'invoice.item.table.item_name' | transloco}}
+     <p-sortIcon field="invoiceNumber"></p-sortIcon>
+   </th>
+   <th pSortableColumn="shortDescription" style="width: 30%">{{'invoice.item.table.short_description' | transloco}}
+     <p-sortIcon field="supplierFullName"></p-sortIcon>
+   </th>
+   <th pSortableColumn="itemPrice" style="width: 25%">{{'invoice.item.table.price' | transloco}}
+     <p-sortIcon field="recipientFullName"></p-sortIcon>
+   </th>
+   <th pSortableColumn="vat" style="width: 15%">{{'invoice.item.table.vat' | transloco}}
+     <p-sortIcon field="invoiceDate"></p-sortIcon>
+   </th>
+   <th style="width: 5%">{{'common.table.manage' | transloco}} </th>
+ </tr>
+</ng-template>
+<ng-template let-catalogitem let-rowIndex="rowIndex" pTemplate="body">
+ <tr (dblclick)="rowDoubleClick($event, catalogitem)" [ngStyle]="{'color':isEditObjectChanged(catalogitem)}"
                 [pSelectableRowIndex]="rowIndex"
                 [pSelectableRow]="catalogitem"
                 title="Double click to edit invoice item">

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/item-management/item-management.component.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/item-management/item-management.component.ts
@@ -19,11 +19,12 @@ import { PaginatorModule } from "primeng/paginator";
 import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
 import {FormsModule} from "@angular/forms";
 import {FloatLabel} from "primeng/floatlabel";
+import {TranslocoPipe} from "@jsverse/transloco";
 
 @Component({
   selector: 'app-item-management',
   standalone: true,
-  imports: [CommonModule, SharedModule, TableModule, ToastModule, InvoicePipesModule, ButtonModule, RippleModule, ConfirmationDialogComponent, EditPersonDialogComponent, EditItemDialogComponent, InputTextModule, PaginatorModule, MatProgressSpinnerModule, FormsModule, FloatLabel],
+  imports: [CommonModule, SharedModule, TableModule, ToastModule, InvoicePipesModule, ButtonModule, RippleModule, ConfirmationDialogComponent, EditPersonDialogComponent, EditItemDialogComponent, InputTextModule, PaginatorModule, MatProgressSpinnerModule, FormsModule, FloatLabel, TranslocoPipe],
   providers: [HttpClient, MessagesPrinter, MessageService],
   templateUrl: './item-management.component.html',
   styleUrls: ['./item-management.component.css']

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/table-cell-renderer/table-cell-renderer.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/invoice/table-cell-renderer/table-cell-renderer.component.html
@@ -1,5 +1,5 @@
 <div role="gridcell">
   <p-button (click)="loadPdfReport($event)" class="printIvoiceButtonFokus printInvoiceButton" icon="pi pi-download"
-            label="Download" styleClass="p-button-text">
+            [label]="'invoice.table_cell.download' | transloco" styleClass="p-button-text">
   </p-button>
 </div>

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/person/edit-person-dialog/edit-person-dialog.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/person/edit-person-dialog/edit-person-dialog.component.html
@@ -8,7 +8,7 @@
 
   <ng-template pTemplate="header">
     <div class="header-dialog-container">
-      <h2 class="dialog-title">Edit person</h2>
+      <h2 class="dialog-title">{{'person.dialog.edit_person' | transloco}}</h2>
 
       <div class="header-actions">
         <button
@@ -37,7 +37,7 @@
           context:{controlPath: 'personType',
                    placeholderPar: 'Select person type',
                    idComponent: 'id-personType',
-                   labelText: 'Person Type',
+                   labelText: 'person.management.table.person_type' | transloco,
                    optionList: personType
                   }">
             </ng-container>
@@ -48,7 +48,7 @@
             <ng-container *ngTemplateOutlet="templatesComponent.inputTextTemplate;
           context:{controlPath: 'personFirstName',
                    idComponent: 'id_firstName',
-                   labelText: 'First name'
+                   labelText: 'person.form.field.first_name' | transloco
                   }">
             </ng-container>
           </div>
@@ -56,7 +56,7 @@
             <ng-container *ngTemplateOutlet="templatesComponent.inputTextTemplate;
           context:{controlPath: 'personLastName',
                    idComponent: 'id_lastName',
-                   labelText: 'Last name'
+                   labelText: 'person.form.field.last_name' | transloco
                   }">
             </ng-container>
           </div>
@@ -67,7 +67,7 @@
             <ng-container *ngTemplateOutlet="templatesComponent.inputTextTemplate;
           context:{controlPath: 'companyName',
                    idComponent: 'id_companyNme',
-                   labelText: 'Company name'
+                   labelText: 'person.form.field.company_name' | transloco
                   }">
             </ng-container>
           </div>
@@ -77,7 +77,7 @@
             <ng-container *ngTemplateOutlet="templatesComponent.inputTextTemplate;
           context:{controlPath: 'email',
                    idComponent: 'id_email',
-                   labelText: 'E-mail'
+                   labelText: 'person.form.field.email' | transloco
                   }">
             </ng-container>
           </div>
@@ -88,7 +88,7 @@
             <ng-container *ngTemplateOutlet="templatesComponent.inputTextTemplate;
           context:{controlPath: 'taxNumber',
                    idComponent: 'id_taxNumber',
-                   labelText: 'Tax number'
+                   labelText: 'person.form.field.tax_number' | transloco
                   }">
             </ng-container>
           </div>
@@ -100,14 +100,14 @@
       <div formGroupName="personAddressFormModel" class="margin-top-20">
         <div class=" shadow-panel-color p-shadow-4 person-edit-panel">
           <div class="p-grid p-col-6" style="margin-left: 5pt">
-            <H2>Person address</H2>
+            <H2>{{'person.form.person_address' | transloco}}</H2>
           </div>
           <div class="p-grid">
             <div class="p-col-2" style="margin-left: 5pt">
               <ng-container *ngTemplateOutlet="templatesComponent.inputTextTemplate;
           context:{controlPath: 'personAddressFormModel.zipCode',
                    idComponent: 'id_zipCode',
-                   labelText: 'Zip code'
+                   labelText: 'person.form.field.zip' | transloco
                   }">
               </ng-container>
             </div>
@@ -115,7 +115,7 @@
               <ng-container *ngTemplateOutlet="templatesComponent.inputTextTemplate;
           context:{controlPath: 'personAddressFormModel.city',
                    idComponent: 'id_city',
-                   labelText: 'City'
+                   labelText: 'person.form.field.city' | transloco
                   }">
               </ng-container>
             </div>
@@ -126,7 +126,7 @@
                 <ng-container *ngTemplateOutlet="templatesComponent.inputTextTemplate;
           context:{controlPath: 'personAddressFormModel.postBoxCode',
                    idComponent: 'id_postBoxCode',
-                   labelText: 'Post Box'
+                   labelText: 'person.form.field.postbox' | transloco
                   }">
                 </ng-container>
               </div>
@@ -136,7 +136,7 @@
                 <ng-container *ngTemplateOutlet="templatesComponent.inputTextTemplate;
           context:{controlPath: 'personAddressFormModel.street',
                    idComponent: 'id_street',
-                   labelText: 'Street'
+                   labelText: 'person.form.field.street' | transloco
                   }">
                 </ng-container>
               </div>
@@ -152,7 +152,7 @@
         <div class="shadow-panel-color p-shadow-4 person-edit-panel">
           <div class="p-grid">
             <div class="p-col-6" style="margin-left: 5pt">
-              <H2>Person bank account</H2>
+              <H2>{{'person.form.person_bank' | transloco}}</H2>
             </div>
           </div>
           <div class="p-grid">
@@ -160,7 +160,7 @@
               <ng-container *ngTemplateOutlet="templatesComponent.inputTextTemplate;
           context:{controlPath: 'bankAccountFormModel.bankName',
                    idComponent: 'id_BankName',
-                   labelText: 'Bank name'
+                   labelText: 'person.form.field.bank' | transloco
                   }">
               </ng-container>
             </div>
@@ -169,7 +169,7 @@
               <ng-container *ngTemplateOutlet="templatesComponent.inputTextTemplate;
             context:{controlPath: 'bankAccountFormModel.accountNumber',
                      idComponent: 'id_AccountNumber',
-                     labelText: 'Account number'
+                     labelText: 'person.form.field.account' | transloco
                   }">
               </ng-container>
             </div>
@@ -180,7 +180,7 @@
               <ng-container *ngTemplateOutlet="templatesComponent.inputTextTemplate;
             context:{controlPath: 'bankAccountFormModel.iban',
                      idComponent: 'id_iban',
-                     labelText: 'IBAN'
+                     labelText: 'person.form.field.iban' | transloco
                   }">
               </ng-container>
             </div>
@@ -188,7 +188,7 @@
               <ng-container *ngTemplateOutlet="templatesComponent.inputTextTemplate;
             context:{controlPath: 'bankAccountFormModel.bicSwift',
                      idComponent: 'id-acc-bicSwift',
-                     labelText: 'BIC/SWIFT'
+                     labelText: 'person.form.field.bic_swift' | transloco
                   }">
               </ng-container>
             </div>
@@ -200,9 +200,9 @@
   </div>
 
   <ng-template pTemplate="footer">
-    <p-button (click)="sendChanges()" [disabled]="haveErrors()" icon="pi pi-check" label="Save"
+    <p-button (click)="sendChanges()" [disabled]="haveErrors()" icon="pi pi-check" label="{{'common.actions.save' | transloco}}"
               styleClass="p-button-text"></p-button>
-    <p-button (click)="setVisible(false)" icon="pi pi-check pink-300" label="Cancel"
+    <p-button (click)="setVisible(false)" icon="pi pi-check pink-300" label="{{'common.actions.cancel' | transloco}}"
               styleClass="p-button-text p-button-secondary"></p-button>
   </ng-template>
 </p-dialog>

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/person/edit-person-dialog/edit-person-dialog.component.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/person/edit-person-dialog/edit-person-dialog.component.ts
@@ -17,11 +17,12 @@ import { MessagesPrinter } from "../../common-services/common-services.app.http.
 import { isAuthenticated, personType } from "../../common-services/common-services-util.service";
 import {FloatLabel} from "primeng/floatlabel";
 import {TemplatesComponentComponent} from "../../common-components/templates-component/templates-component.component";
+import {TranslocoPipe} from "@jsverse/transloco";
 
 @Component({
   selector: 'app-edit-person-dialog',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, AngularIbanModule, ButtonModule, InputTextModule, MessageModule, ToastModule, ValidatableDropdownlistModule, DropdownModule, DialogModule, FloatLabel, TemplatesComponentComponent],
+  imports: [CommonModule, ReactiveFormsModule, AngularIbanModule, ButtonModule, InputTextModule, MessageModule, ToastModule, ValidatableDropdownlistModule, DropdownModule, DialogModule, FloatLabel, TemplatesComponentComponent, TranslocoPipe],
   templateUrl: './edit-person-dialog.component.html',
   styleUrls: ['./edit-person-dialog.component.css']
 })

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/person/person-management/person-management.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/person/person-management/person-management.component.html
@@ -3,7 +3,7 @@
     <p-toast></p-toast>
     <div class="p-grid base-top-grid-area">
       <div class="p-col-12">
-        <H2 style="margin-left: 10pt;">Person management</H2>
+        <H2 style="margin-left: 10pt;">{{ 'person.management.title' | transloco }}</H2>
       </div>
       <div class="p-col-12" *ngIf="environment.debugMode">
         <p>
@@ -24,25 +24,25 @@
                    paginator="true" selectionMode="multiple" styleClass="p-datatable-gridlines">
             <ng-template pTemplate="header">
               <tr>
-                <th pSortableColumn="personLastName" style="width: 20%">Person last name
+                <th pSortableColumn="personLastName" style="width: 20%">{{ 'person.management.table.last_name' | transloco }}
                   <p-sortIcon field="personLastName"></p-sortIcon>
                 </th>
-                <th pSortableColumn="personFirstName" style="width: 20%">Person first name
+                <th pSortableColumn="personFirstName" style="width: 20%">{{ 'person.management.table.first_name' | transloco }}
                   <p-sortIcon field="personLastName"></p-sortIcon>
                 </th>
-                <th pSortableColumn="companyName" style="width: 25%">Company name
+                <th pSortableColumn="companyName" style="width: 25%">{{ 'person.management.table.company_name' | transloco }}
                   <p-sortIcon field="companyName"></p-sortIcon>
                 </th>
-                <th pSortableColumn="personType" style="width: 10%">Person type
+                <th pSortableColumn="personType" style="width: 10%">{{ 'person.management.table.person_type' | transloco }}
                   <p-sortIcon field="personType"></p-sortIcon>
                 </th>
-                <th pSortableColumn="taxNumber" style="width: 10%">Tax number
+                <th pSortableColumn="taxNumber" style="width: 10%">{{ 'person.management.table.tax_number' | transloco }}
                   <p-sortIcon field="taxNumber"></p-sortIcon>
                 </th>
-                <th pSortableColumn="email" style="width: 15%">E-mail
+                <th pSortableColumn="email" style="width: 15%">{{ 'person.management.table.email' | transloco }}
                   <p-sortIcon field="email"></p-sortIcon>
                 </th>
-                <th style="width: 5%">Manage</th>
+                <th style="width: 5%">{{ 'common.table.manage' | transloco }}</th>
               </tr>
             </ng-template>
 
@@ -50,7 +50,7 @@
               <tr (dblclick)="rowDoubleClick($event, person)" [ngStyle]="{'color':isPersonChanged(person)}"
                   [pSelectableRowIndex]="rowIndex"
                   [pSelectableRow]="person"
-                  title="Double click to edit person">
+                  title="{{ 'person.management.tooltips.edit_person' | transloco }}">
                 <td style="padding: 5pt 2pt 2pt 2pt;">
                   <div>{{person.personLastName}}</div>
                 </td>
@@ -72,18 +72,18 @@
                 <td style="padding: 5pt 2pt 2pt 2pt;">
                   <button (click)="deletePerson(person.id)" class="p-button-rounded p-button-warning"
                           pButton pRipple
-                          title="Delete item">
+                          title="{{ 'common.tooltips.delete_item' | transloco }}">
                     <i class="pi pi-trash"></i>
                   </button>
                   <button (click)="rowDoubleClick($event, person)" class="p-button-rounded p-button-warning undo-button"
                           pButton pRipple
-                          title="Edit item">
+                          title="{{ 'common.tooltips.edit_item' | transloco }}">
                     <i class="pi pi-pencil"></i>
                   </button>
                   <button (click)="rollbackChanges(person.id)" class="p-button-rounded p-button-warning undo-button"
                           pButton
                           pRipple
-                          title="Rollback item">
+                          title="{{ 'common.tooltips.rollback_item' | transloco }}">
                     <i class="pi pi-undo"></i>
                   </button>
                 </td>
@@ -95,7 +95,7 @@
       </div>
       <div class="p-col-12 save-button-col-size">
         <div class="save-button-container-size">
-          <p-button (onClick)="saveChangedPersons($event)" [disabled]="haveNoChanges()" label="Save"/>
+          <p-button (onClick)="saveChangedPersons($event)" [disabled]="haveNoChanges()" [label]="'common.actions.save' | transloco"/>
         </div>
       </div>
     </div>
@@ -108,7 +108,7 @@
 
     <app-confirmation-dialog #confirmDialog
                              (canceled)="handleCancel($event)"
-                             [confirmMessage]="'Confirm delete person'"
+                             [confirmMessage]="'person.management.confirm.delete' | transloco"
                              (confirmed)="handleConfirmation(confirmDialog.transferObject)"
                              [display]="showConfirmDialog"
                              [message]="confirmDialogMessage"></app-confirmation-dialog>

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/person/person-management/person-management.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/person/person-management/person-management.component.html
@@ -95,7 +95,7 @@
       </div>
       <div class="p-col-12 save-button-col-size">
         <div class="save-button-container-size">
-          <p-button (onClick)="saveChangedPersons($event)" [disabled]="haveNoChanges()" [label]="'common.actions.save' | transloco"/>
+          <p-button (onClick)="saveChangedPersons($event)" [disabled]="haveNoChanges()" [label]="'actions.save' | transloco"/>
         </div>
       </div>
     </div>

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/person/person-management/person-management.component.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/person/person-management/person-management.component.ts
@@ -19,11 +19,12 @@ import { CommonServicesEditService } from "../../common-services/common-services
 import { HttpClient } from "@angular/common/http";
 import { environment } from "../../../environments/environment";
 import { CommonServiceEventBus } from "../../common-services/common-service.event.bus";
+import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 
 @Component({
   selector: 'app-person-management',
   standalone: true,
-  imports: [CommonModule, TableModule, ToastModule, MatProgressSpinnerModule, DateperiodFinderComponent, EditPersonDialogComponent, ReactiveFormsModule, DialogModule, InputTextModule, ButtonModule, RippleModule, ConfirmationDialogComponent],
+  imports: [CommonModule, TableModule, ToastModule, MatProgressSpinnerModule, DateperiodFinderComponent, EditPersonDialogComponent, ReactiveFormsModule, DialogModule, InputTextModule, ButtonModule, RippleModule, ConfirmationDialogComponent, TranslocoModule],
   templateUrl: './person-management.component.html',
   styleUrls: ['./person-management.component.css'],
   providers: [AppSecurityService, HttpClient]
@@ -40,17 +41,19 @@ export class PersonManagementComponent extends CommonServicesEditService<PersonF
   selectedPerson!: PersonFormModel
   keySelection: boolean = true;
   showConfirmDialog: boolean;
-  confirmDialogMessage: string = 'Are you sure you want to delete the person?';
+  confirmDialogMessage: string = '';
   protected readonly isAuthenticated = isAuthenticated;
   @Input() eventBusVal: any
 
   constructor(public appSecurityService: AppSecurityService,
-              private httpService: CommonServicesAppHttpService<PersonFormModel[]>, private eventListener: CommonServiceEventBus<any>) {
+              private httpService: CommonServicesAppHttpService<PersonFormModel[]>, private eventListener: CommonServiceEventBus<any>,
+              private translocoService: TranslocoService) {
     super(httpService.httpClient, 'Can not load items catalog by criteria: ', 'invoice/itemsCatalogList')
 
   }
 
   ngOnInit(): void {
+    this.confirmDialogMessage = this.translocoService.translate('person.management.confirm.delete_message')
     if (environment.debugMode) {
       this.eventListener.onEvent().subscribe(val =>{
         this.eventBusVal= JSON.stringify(val)

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/person/personform/personform.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/person/personform/personform.component.html
@@ -2,31 +2,48 @@
 <div class="p-fluid">
   <p-toast></p-toast>
   <div class="p-grid p-col-6">
-    <H2>Create Person</H2>
+    <H2>{{'person.form.create_person' | transloco}}</H2>
   </div>
   <form #personForm="ngForm">
     <div class=" p-shadow-4">
       <div class="p-grid item-left">
         <div class="p-col-6 ">
-          <app-validatable-dropdownlist (componentHasError)="setHasPersonTypeError($event)"
-                                        (valueChanged)="peronTypeChanged($event)"
-                                        [(ngModel)]="personFormModel.personType"
-                                        [idComponent]="'id-personType'"
-                                        [labelText]="'Person Type'"
-                                        [optionList]="personType"
-                                        [txtMinLength]="1"
-                                        inputName="personType"
-                                        name="personType">
-          </app-validatable-dropdownlist>
+          <!--
+          "field": {
+          "first_name": "First name",
+          "last_name": "Las name",
+          "email": "Email",
+          "company_name": "Company name",
+          "tax_number": "Tax number",
+          "zip": "Zip",
+          "city": "City",
+          "postbox": "Post box",
+          "street": "Street",
+          "bank": "Bank name",
+          "account": "Account number",
+          "iban": "IBAN",
+          "bic_swift": "BIC/SWIFT"
+          -->
+
+            <app-validatable-dropdownlist (componentHasError)="setHasPersonTypeError($event)"
+                                          (valueChanged)="peronTypeChanged($event)"
+                                          [(ngModel)]="personFormModel.personType"
+                                          [idComponent]="'id-personType'"
+                                          [labelText]="'person.management.table.person_type' | transloco"
+                                          [optionList]="personType"
+                                          [txtMinLength]="1"
+                                          inputName="personType"
+                                          name="personType">
+            </app-validatable-dropdownlist>
+          </div>
         </div>
-      </div>
-      @if (personFormModel.personType==='PRIVATE') {
+        @if (personFormModel.personType==='PRIVATE') {
         <div class="p-grid item-left">
         <div class="p-col-3">
           <app-validatable-input-text (componentHasErrorEvent)="setHasFirstNameError($event)"
                                       [(ngModel)]="personFormModel.personFirstName"
                                       [idComponent]="'id_firstName'"
-                                      [labelText]="'First name'"
+                                      [labelText]="'person.form.field.first_name' | transloco"
                                       [txtMinLength]="2"
                                       inputName="personFirstName"
                                       name="personFirstName">
@@ -36,7 +53,7 @@
           <app-validatable-input-text (componentHasErrorEvent)="setHasLastNameError($event)"
                                       [(ngModel)]="personFormModel.personLastName"
                                       [idComponent]="'id_lastName'"
-                                      [labelText]="'Last name'"
+                                      [labelText]="'person.form.field.last_name' | transloco"
                                       [txtMinLength]="2"
                                       inputName="personLastName"
                                       name="personLastName">
@@ -49,7 +66,7 @@
             <app-validatable-input-text (componentHasErrorEvent)="setHasCompanyNameError($event)"
                                         [(ngModel)]="personFormModel.companyName"
                                         [idComponent]="'id_company_Name'"
-                                        [labelText]="'Company name'"
+                                        [labelText]="'person.form.field.company_name' | transloco"
                                         [txtMinLength]="2"
                                         inputName="companyName"
                                         name="companyName">
@@ -64,7 +81,7 @@
                                       [idComponent]="'id_email'"
                                       [inputPattern]="emailPattern"
                                       [inputType]="'text'"
-                                      [labelText]="'E-mail'"
+                                      [labelText]="'person.form.field.email' | transloco"
                                       [txtMinLength]="5"
                                       name="email"
                                       patternErrorText="Wrong email">
@@ -76,7 +93,7 @@
           <app-validatable-input-text (componentHasErrorEvent)="setHasTaxNumberError($event)"
                                       [(ngModel)]="personFormModel.taxNumber"
                                       [idComponent]="'id_tax_Number'"
-                                      [labelText]="'Tax number'"
+                                      [labelText]="'person.form.field.tax_number' | transloco"
                                       [txtMinLength]="5"
                                       inputName="taxNumber"
                                       name="taxNumber">
@@ -85,7 +102,7 @@
 }
     </div>
     <div class="p-grid p-col-6">
-      <H2>Person address</H2>
+      <H2>{{'person.form.person_address' | transloco}}</H2>
     </div>
     <div class=" p-shadow-4">
 
@@ -94,7 +111,7 @@
           <app-validatable-input-text (componentHasErrorEvent)="setHasZipCodeError($event)"
                                       [(ngModel)]="personFormModel.personAddressFormModel.zipCode"
                                       [idComponent]="'id_Zip'"
-                                      [labelText]="'Zip'"
+                                      [labelText]="'person.form.field.zip' | transloco"
                                       [txtMinLength]="4"
                                       inputName="zipCode"
                                       name="zipCode">
@@ -104,7 +121,7 @@
           <app-validatable-input-text (componentHasErrorEvent)="setHasCityError($event)"
                                       [(ngModel)]="personFormModel.personAddressFormModel.city"
                                       [idComponent]="'id_City'"
-                                      [labelText]="'City'"
+                                      [labelText]="'person.form.field.city' | transloco"
                                       [txtMinLength]="2"
                                       inputName="city"
                                       name="city">
@@ -118,7 +135,7 @@
                    name="postBoxCode" pInputText
                    style="margin-left: 0px !Important"
                    type="text"/>
-            <label for="id-add-postBoxCode">Post Box</label>
+            <label for="id-add-postBoxCode">{{'person.form.field.postbox' | transloco}}</label>
           </p-floatlabel>
         </div>
         <div class="p-col-3 street-container">
@@ -126,7 +143,7 @@
             <app-validatable-input-text (componentHasErrorEvent)="setHasStreetError($event)"
                                         [(ngModel)]="personFormModel.personAddressFormModel.street"
                                         [idComponent]="'id_Street'"
-                                        [labelText]="'Street'"
+                                        [labelText]="'person.form.field.street' | transloco"
                                         [txtMinLength]="2"
                                         inputName="street"
                                         name="street">
@@ -146,7 +163,7 @@
           <app-validatable-input-text (componentHasErrorEvent)="setHasBankNameError($event)"
                                       [(ngModel)]="personFormModel.bankAccountFormModel.bankName"
                                       [idComponent]="'id_BankName'"
-                                      [labelText]="'Bank name'"
+                                      [labelText]="'person.form.field.bank' | transloco"
                                       [txtMinLength]="2"
                                       inputName="bankName"
                                       name="bankName">
@@ -159,7 +176,7 @@
                    name="accountNumber"
                    pInputText
                    type="text"/>
-            <label for="id_AccountNumber">Account number</label>
+            <label for="id_AccountNumber">{{'person.form.field.account' | transloco}}</label>
           </p-floatlabel>
         </div>
       </div>
@@ -180,7 +197,7 @@
                            pInputText
                            required
                            type="text"/>
-                  <label for="id_IBAN">IBAN</label>
+                  <label for="id_IBAN">{{'person.form.field.iban' | transloco}}</label>
                </p-floatlabel>
               </div>
               @if (modelRef.errors?.['required']) {
@@ -195,7 +212,7 @@
               }
             </div>
             @if(modelRef.errors?.['iban']) {
-              <p-message severity="error" text="Wrong IBAN"></p-message>
+              <p-message severity="error" text="{{'person.form.field.wrong_iban_format' | transloco}}"></p-message>
             }
           </div>
         </div>
@@ -204,7 +221,7 @@
           <app-validatable-input-text (componentHasErrorEvent)="setHasBicError($event)"
                                       [(ngModel)]="personFormModel.bankAccountFormModel.bicSwift"
                                       [idComponent]="'id-acc-bicSwift'"
-                                      [labelText]="'BIC/SWIFT'"
+                                      [labelText]="'person.form.field.bic_swift' | transloco"
                                       [txtMinLength]="5"
                                       inputName="bicSwift"
                                       name="bicSwift">
@@ -217,11 +234,11 @@
         <div *ngIf=" createPersonType === undefined; else elseBlock">
           <p-button (onClick)="savePerson(false)" [disabled]="this.personForm?.invalid"
                     class="save-button-col-size save-button-container-size"
-                    label="Save"></p-button>
+                    label="{{'common.actions.save' | transloco}}"></p-button>
         </div>
         <ng-template #elseBlock>
           <p-button (onClick)="savePerson(true)" [disabled]="this.personForm?.invalid"
-                    class="save-button-col-size save-button-container-size" label="Save and return"></p-button>
+                    class="save-button-col-size save-button-container-size" label="{{'person.save_and_return' | transloco}}Save and return"></p-button>
         </ng-template>
       </div>
     </div>

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/person/personform/personform.component.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/person/personform/personform.component.ts
@@ -60,6 +60,7 @@ import {
   ValidatableInputTextComponent
 } from "../../common-components/validatable-input-text/validatable-input-text.component";
 import {FloatLabel} from "primeng/floatlabel";
+import {TranslocoPipe} from "@jsverse/transloco";
 
 /**
  * The component which contains form component for creation of person
@@ -317,7 +318,7 @@ export class PersonFormComponent implements OnInit, OnDestroy {
 @NgModule(
   {
     imports: [CommonModule, FormsModule, ButtonModule, ValidatableDropdownlistModule,
-      MessagesModule, MessageModule, ToastModule, InputTextModule, AngularIbanModule, InvoicePipesModule, WorkflowModule, ValidatableInputTextComponent, FloatLabel],
+      MessagesModule, MessageModule, ToastModule, InputTextModule, AngularIbanModule, InvoicePipesModule, WorkflowModule, ValidatableInputTextComponent, FloatLabel, TranslocoPipe],
     declarations: [PersonFormComponent],
     exports: [PersonFormComponent],
   }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/transloco/transloco-loader.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/transloco/transloco-loader.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { TranslocoLoader, Translation } from '@jsverse/transloco';
+import { forkJoin, map, Observable } from 'rxjs';
+
+const TRANSLATION_SCOPES = ['app', 'auth', 'common', 'invoice', 'person', 'workflow'];
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function mergeTranslations(target: Translation, source: Translation): Translation {
+  const result: Translation = {...target};
+
+  Object.keys(source).forEach((key) => {
+    const sourceValue = source[key];
+    const targetValue = result[key];
+
+    if (isObject(sourceValue) && isObject(targetValue)) {
+      result[key] = mergeTranslations(targetValue as Translation, sourceValue as Translation);
+      return;
+    }
+
+    result[key] = sourceValue;
+  });
+
+  return result;
+}
+
+@Injectable({ providedIn: 'root' })
+export class MultiJsonTranslocoHttpLoader implements TranslocoLoader {
+  constructor(private http: HttpClient) {}
+
+  getTranslation(lang: string): Observable<Translation> {
+    const requests = TRANSLATION_SCOPES.map((scope) =>
+      this.http.get<Translation>(`assets/i18n/${lang}/${scope}.json`)
+    );
+
+    return forkJoin(requests).pipe(
+      map((translations) => translations.reduce((acc, current) => mergeTranslations(acc, current), {} as Translation))
+    );
+  }
+}

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/transloco/transloco.providers.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/transloco/transloco.providers.ts
@@ -1,23 +1,15 @@
-import { Provider } from '@angular/core';
-import {
-  TRANSLOCO_CONFIG,
-  TRANSLOCO_LOADER,
-  translocoConfig,
-} from '@jsverse/transloco';
+import { provideTransloco, translocoConfig } from '@jsverse/transloco';
 import { MultiJsonTranslocoHttpLoader } from './transloco-loader';
+import { environment } from '../../environments/environment';
 
-export const translocoProviders: Provider[] = [
-  {
-    provide: TRANSLOCO_CONFIG,
-    useValue: translocoConfig({
+export const translocoProviders = [
+  provideTransloco({
+    config: translocoConfig({
       availableLangs: ['en', 'de'],
       defaultLang: 'en',
       reRenderOnLangChange: true,
-      prodMode: false,
+      prodMode: environment.production,
     }),
-  },
-  {
-    provide: TRANSLOCO_LOADER,
-    useClass: MultiJsonTranslocoHttpLoader,
-  },
+    loader: MultiJsonTranslocoHttpLoader,
+  }),
 ];

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/transloco/transloco.providers.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/transloco/transloco.providers.ts
@@ -1,0 +1,23 @@
+import { Provider } from '@angular/core';
+import {
+  TRANSLOCO_CONFIG,
+  TRANSLOCO_LOADER,
+  translocoConfig,
+} from '@jsverse/transloco';
+import { MultiJsonTranslocoHttpLoader } from './transloco-loader';
+
+export const translocoProviders: Provider[] = [
+  {
+    provide: TRANSLOCO_CONFIG,
+    useValue: translocoConfig({
+      availableLangs: ['en', 'de'],
+      defaultLang: 'en',
+      reRenderOnLangChange: true,
+      prodMode: false,
+    }),
+  },
+  {
+    provide: TRANSLOCO_LOADER,
+    useClass: MultiJsonTranslocoHttpLoader,
+  },
+];

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/transloco/transloco.providers.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/transloco/transloco.providers.ts
@@ -6,7 +6,7 @@ export const translocoProviders = [
   provideTransloco({
     config: translocoConfig({
       availableLangs: ['en', 'de'],
-      defaultLang: 'en',
+      defaultLang: 'de',
       reRenderOnLangChange: true,
       prodMode: environment.production,
     }),

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/user/user-login/user-login.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/user/user-login/user-login.component.html
@@ -15,7 +15,7 @@
         <div class="p-grid">
           <div class="p-col-1"></div>
           <div class="p-col-3" style="text-align: center"></div>
-          <H2>Please login to the system</H2>
+          <H2>{{ 'auth.login.heading' | transloco }}</H2>
           <div class="p-col-3"></div>
         </div>
         <div class="p-grid">
@@ -23,7 +23,7 @@
           <div class="p-col-6">
             <app-validatable-input-text [(ngModel)]="appSecurityService.credentials.username"
                                         [idComponent]="'id_UserName'"
-                                        [labelText]="'User name'"
+                                        [labelText]="'auth.login.fields.username' | transloco"
                                         [name]="'user_name'"
                                         [txtMinLength]="2">
             </app-validatable-input-text>
@@ -36,7 +36,7 @@
             <app-validatable-input-text [(ngModel)]="appSecurityService.credentials.password"
                                         [idComponent]="'id_UserPassword'"
                                         [inputType]="'password'"
-                                        [labelText]="'Password'"
+                                        [labelText]="'auth.login.fields.password' | transloco"
                                         [name]="'password'"
                                         [txtMinLength]="5">
             </app-validatable-input-text>
@@ -45,12 +45,12 @@
         </div>
         <div style="text-align: center; margin-bottom: 10pt;">
           <a ariaCurrentWhenActive="page" class="nav-item nav-link" routerLink="/user-registration-page"
-             routerLinkActive="active">Register new user</a>
+             routerLinkActive="active">{{ 'auth.login.actions.register' | transloco }}</a>
         </div>
         <div class="p-grid">
           <div class="p-col-5"></div>
           <div class="p-col-2">
-            <p-button icon="pi pi-check" label="Login" styleClass="p-button-text submit-button"
+            <p-button icon="pi pi-check" [label]="'auth.login.actions.login' | transloco" styleClass="p-button-text submit-button"
                       type="submit"></p-button>
           </div>
           <div class="p-col-4"></div>

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/user/user-login/user-login.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/user/user-login/user-login.component.html
@@ -15,7 +15,7 @@
         <div class="p-grid">
           <div class="p-col-1"></div>
           <div class="p-col-3" style="text-align: center"></div>
-          <H2>{{ 'auth.login.heading' | transloco }}</H2>
+          <H2>{{ 'login.heading' | transloco }}</H2>
           <div class="p-col-3"></div>
         </div>
         <div class="p-grid">
@@ -23,7 +23,7 @@
           <div class="p-col-6">
             <app-validatable-input-text [(ngModel)]="appSecurityService.credentials.username"
                                         [idComponent]="'id_UserName'"
-                                        [labelText]="'auth.login.fields.username' | transloco"
+                                        [labelText]="'login.fields.username' | transloco"
                                         [name]="'user_name'"
                                         [txtMinLength]="2">
             </app-validatable-input-text>
@@ -36,7 +36,7 @@
             <app-validatable-input-text [(ngModel)]="appSecurityService.credentials.password"
                                         [idComponent]="'id_UserPassword'"
                                         [inputType]="'password'"
-                                        [labelText]="'auth.login.fields.password' | transloco"
+                                        [labelText]="'login.fields.password' | transloco"
                                         [name]="'password'"
                                         [txtMinLength]="5">
             </app-validatable-input-text>
@@ -45,12 +45,12 @@
         </div>
         <div style="text-align: center; margin-bottom: 10pt;">
           <a ariaCurrentWhenActive="page" class="nav-item nav-link" routerLink="/user-registration-page"
-             routerLinkActive="active">{{ 'auth.login.actions.register' | transloco }}</a>
+             routerLinkActive="active">{{ 'login.actions.register' | transloco }}</a>
         </div>
         <div class="p-grid">
           <div class="p-col-5"></div>
           <div class="p-col-2">
-            <p-button icon="pi pi-check" [label]="'auth.login.actions.login' | transloco" styleClass="p-button-text submit-button"
+            <p-button icon="pi pi-check" [label]="'login.actions.login' | transloco" styleClass="p-button-text submit-button"
                       type="submit"></p-button>
           </div>
           <div class="p-col-4"></div>

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/user/user-login/user-login.component.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/user/user-login/user-login.component.ts
@@ -4,6 +4,7 @@ import { HttpClient } from '@angular/common/http';
 import { Router, RouterModule } from '@angular/router';
 import { MessageService } from 'primeng/api';
 import {Observable, of, share} from "rxjs";
+import { TranslocoModule, TranslocoService } from "@jsverse/transloco";
 import { FormsModule, NgForm } from "@angular/forms";
 import { CommonModule } from "@angular/common";
 import { ButtonModule } from "primeng/button";
@@ -30,7 +31,8 @@ export class UserLoginComponent implements OnInit {
 
   constructor(public appSecurityService: AppSecurityService,
               private http: HttpClient, public router: Router,
-              private messageService: MessageService) {
+              private messageService: MessageService,
+              private translocoService: TranslocoService) {
     //this.backendUrl = environment.baseUrl;
     this.observableMsgService = of(messageService);
   }
@@ -81,8 +83,8 @@ export class UserLoginComponent implements OnInit {
           console.log('Not logged :' + result);
           this.observableMsgService.subscribe(m => {
             m.add({
-              severity: 'error', summary: 'Loging error',
-              detail: 'Please enter correct user name and password.'
+              severity: 'error', summary: this.translocoService.translate('auth.login.error.summary'),
+              detail: this.translocoService.translate('auth.login.error.invalid_credentials')
             });
           })
 
@@ -95,7 +97,7 @@ export class UserLoginComponent implements OnInit {
 @NgModule(
   {
     imports: [CommonModule, FormsModule, ButtonModule, MessagesModule,
-      MessageModule, ToastModule, RouterModule, ValidatableInputTextComponent],
+      MessageModule, ToastModule, RouterModule, ValidatableInputTextComponent, TranslocoModule],
     declarations: [UserLoginComponent],
     exports: [UserLoginComponent]
   }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/workflows/invoice-workflow/invoice-workflow.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/workflows/invoice-workflow/invoice-workflow.component.html
@@ -30,7 +30,7 @@
                           <app-validatable-input-text (componentHasErrorEvent)="setHasInvoiceNumberError($event)"
                                                       [(ngModel)]="invoice.invoiceNumber"
                                                       [idComponent]="'id_InvoiceNumber'"
-                                                      [labelText]="'Invoice Number'"
+                                                      [labelText]="'invoice.number' | transloco"
                                                       [name]="'invoiceNumber'"
                                                       [txtMinLength]="5">
                           </app-validatable-input-text>
@@ -51,7 +51,7 @@
                           <app-validatable-dropdownlist (componentHasError)="setHasInvoiceratesError($event)"
                                                         [(ngModel)]="invoice.rateType"
                                                         [idComponent]="'id-rateType'"
-                                                        [labelText]="'Rate Type'"
+                                                        [labelText]="'invoice.rate_type' | transloco"
                                                         [name]="'invoiceRatesList'"
                                                         [optionList]="invoiceRate"
                                                         [txtMinLength]="1">
@@ -70,7 +70,7 @@
                                                 [(ngModel)]="invoice.creationDate"
                                                 [dateFormat]="'dd.mm.yy'"
                                                 [idComponent]="'id-creationDate'"
-                                                [labelText]="'Creation Date'"
+                                                [labelText]="'invoice.creation_date' | transloco"
                                                 [name]="'creationDate'"
                                                 calendarDateFormat="dd.mm.yy"
                                                 maxlength="10">
@@ -82,7 +82,7 @@
                                                 [(ngModel)]="invoice.invoiceDate"
                                                 [dateFormat]="'dd.mm.yy'"
                                                 [idComponent]="'id-InvoiceDate'"
-                                                [labelText]="'Invoice Date'"
+                                                [labelText]="'invoice.invoice_date' | transloco"
                                                 [name]="'invoiceDate'"
                                                 calendarDateFormat="dd.mm.yy"
                                                 maxlength="10">
@@ -99,7 +99,7 @@
                                                     (ngModelChange)="onSupplierChanged($event)"
 
                                                     [idComponent]="'id-invoiceCreator'"
-                                                    [labelText]="'Invoice creator person'"
+                                                    [labelText]="'invoice.person_creator' | transloco"
                                                     [name]="'creator'"
                                                     [ngModel]="invoice.personSupplierId"
                                                     [optionList]="personInvoiceSupplier"
@@ -108,7 +108,7 @@
                       </app-validatable-dropdownlist>
                     </div>
                     <div class="p-col-2" style="max-width: 50%;">
-                      <p-button (onClick)="createInvoiceCreator()" label="Create"></p-button>
+                      <p-button (onClick)="createInvoiceCreator()" label="{{'person.form.create_person' | transloco}}"></p-button>
                     </div>
                   </div>
                 </div>
@@ -120,7 +120,7 @@
                       <app-validatable-dropdownlist (componentHasError)="setHasRecipientError($event)"
                                                     [(ngModel)]="invoice.personRecipientId"
                                                     [idComponent]="'id-invoiceRecipient'"
-                                                    [labelText]="'Invoice recipient person'"
+                                                    [labelText]="'invoice.person_recipient' | transloco"
                                                     [name]="'recipient'"
                                                     [optionList]="personInvoiceRecipient"
                                                     [placeholder]="'Select person'"
@@ -128,7 +128,7 @@
                       </app-validatable-dropdownlist>
                     </div>
                     <div class="p-col-2" style="max-width: 50%;">
-                      <p-button (onClick)="createInvoiceRecipient()" label="Create"></p-button>
+                      <p-button (onClick)="createInvoiceRecipient()" label="{{'person.form.create_person' | transloco}}"></p-button>
                     </div>
                   </div>
                 </div>
@@ -149,7 +149,7 @@
               @if (flowEvent.level === 5) {
                 <div *ngIf="currentStatus.level > 4" [ngStyle]="editStyle(5)" class="p-col-2">
                   <p-button (onClick)="saveInvoice($event)" [disabled]="haveErrors(workflowInvoiceItems)"
-                            label="Persist invoice"></p-button>
+                            label="{{'common.action.save' | transloco}}"></p-button>
                 </div>
               }
               <div class="p-col-3">
@@ -169,230 +169,3 @@
       </div>
     </div>
   </div>
-
-
-<!--
-<p-splitter *ngIf="isAuthenticated();" [panelSizes]="[75, 25]" [minSizes]="[20, 50]"
-            [style]="{ height: '100%' }" styleClass="app-splitter">
-  <ng-template pTemplate>
-    <div class="p-grid" style="background-color: #f6f9fb;">
-      <div class="p-col-12" style="height: 5%">
-        <h2>Workflow steps</h2>
-      </div>
-      <div class="p-col-12" style=" height: 95%">
-        <div class="card flex flex-wrap gap-6" style="height: 100%;">
-          <p-timeline [value]="createInvoiceFlowEvents" align="right" class="w-full md:w-20rem">
-
-            <ng-template let-flowEvent pTemplate="opposite">
-              <div class="timeline-opposite">
-                TEST: {{flowEvent.level}}
-                @if (flowEvent.level === 0) {
-                 <div [ngStyle]="editStyle(0)" class="p-col-12">
-                  <div class="p-grid">
-                    <div class="p-col-12">
-                      <div class="p-grid">
-                        <div class="p-col-4" style="margin-top: 10pt">
-                          <app-validatable-input-text (componentHasErrorEvent)="setHasInvoiceNumberError($event)"
-                                                      [(ngModel)]="invoice.invoiceNumber"
-                                                      [idComponent]="'id_InvoiceNumber'"
-                                                      [labelText]="'Invoice Number'"
-                                                      [name]="'invoiceNumber'"
-                                                      [txtMinLength]="5">
-                          </app-validatable-input-text>
-                        </div>
-                        <div class="p-col-4" style="margin-top: 10pt">
-             <span class="p-float-label">
-               <input [(ngModel)]="invoice.invoiceDescription" id="id-invoiceDescription" name="'invoiceDescription'"
-                      pInputText
-                      style="width:100%;" type="text"/>
-               <label for="id-invoiceDescription">Invoice description</label>
-             </span>
-                        </div>
-                      </div>
-                    </div>
-                    <div class="p-col-12">
-                      <div class="p-grid">
-                        <div class="p-col-3" style="margin-top: 15pt">
-                          <app-validatable-dropdownlist (componentHasError)="setHasInvoiceratesError($event)"
-                                                        [(ngModel)]="invoice.rateType"
-                                                        [idComponent]="'id-rateType'"
-                                                        [labelText]="'Rate Type'"
-                                                        [name]="'invoiceRatesList'"
-                                                        [optionList]="invoiceRate"
-                                                        [txtMinLength]="1">
-                          </app-validatable-dropdownlist>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                }
-
-              </div>
-            </ng-template>
-
-            <ng-template let-flowEvent pTemplate="content">
-              <p-button (onClick)="setWorkflowStep(flowEvent)" class="p-button-link flow-button-unselected timeline-button-style" >
-                <div [ngStyle]="flowButtonStyle(flowEvent)" class="flow-button-unselected"
-                     style="padding: 8pt 8pt 8pt 8pt;">
-                  {{ flowEvent.statusDesc }}
-                </div>
-              </p-button>
-            </ng-template>
-            <ng-template let-flowEvent  pTemplate="marker">
-                       <span *ngIf="getTimelineIcon(flowEvent)" class="custom-marker">
-                          <i [ngClass]="flowEvent.clsName"></i>
-                       </span>
-            </ng-template>
-
-          </p-timeline>
-        </div>
-      </div>
-    </div>
-  </ng-template>
-  <ng-template pTemplate>
-    <form   #workflowFrm = "ngForm" class="w-100">
-    <div class="p-grid p-fluid" style="height: fit-content; margin-left: 10pt;">
-      <div class="p-col-12" style="height: 5%;">
-        <div>
-          <h2>Create invoice panel</h2>
-        </div>
-        <div style="width: 20%">
-          <p-button (onClick)="resetModel(); resetErrors();" label="Reset"></p-button>
-        </div>
-      </div>
-      <div [ngStyle]="editStyle(0)" class="p-col-12">
-        <div class="p-grid">
-          <div class="p-col-12">
-            <div class="p-grid">
-              <div class="p-col-4" style="margin-top: 10pt">
-                <app-validatable-input-text (componentHasErrorEvent)="setHasInvoiceNumberError($event)"
-                                            [(ngModel)]="invoice.invoiceNumber"
-                                            [idComponent]="'id_InvoiceNumber'"
-                                            [labelText]="'Invoice Number'"
-                                            [name]="'invoiceNumber'"
-                                            [txtMinLength]="5">
-                </app-validatable-input-text>
-              </div>
-              <div class="p-col-4" style="margin-top: 10pt">
-             <span class="p-float-label">
-               <input [(ngModel)]="invoice.invoiceDescription" id="id-invoiceDescription" name="'invoiceDescription'"
-                      pInputText
-                      style="width:100%;" type="text"/>
-               <label for="id-invoiceDescription">Invoice description</label>
-             </span>
-              </div>
-            </div>
-          </div>
-          <div class="p-col-12">
-            <div class="p-grid">
-              <div class="p-col-3" style="margin-top: 15pt">
-                <app-validatable-dropdownlist (componentHasError)="setHasInvoiceratesError($event)"
-                                              [(ngModel)]="invoice.rateType"
-                                              [idComponent]="'id-rateType'"
-                                              [labelText]="'Rate Type'"
-                                              [name]="'invoiceRatesList'"
-                                              [optionList]="invoiceRate"
-                                              [txtMinLength]="1">
-                </app-validatable-dropdownlist>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div *ngIf="currentStatus.level > 0" class="p-col-12">
-        <div [ngStyle]="editStyle(1)" class="p-grid">
-          <div class="p-col-3">
-            <app-validatable-calendar (componentHasError)="setHasCreationDateError($event)"
-                                      [(ngModel)]="invoice.creationDate"
-                                      [dateFormat]="'dd.mm.yy'"
-                                      [idComponent]="'id-creationDate'"
-                                      [labelText]="'Creation Date'"
-                                      [name]="'creationDate'"
-                                      calendarDateFormat="dd.mm.yy"
-                                      maxlength="10">
-            </app-validatable-calendar>
-          </div>
-
-          <div class="p-col-3">
-            <app-validatable-calendar (componentHasError)="setHasInvoiceDateError($event)"
-                                      [(ngModel)]="invoice.invoiceDate"
-                                      [dateFormat]="'dd.mm.yy'"
-                                      [idComponent]="'id-InvoiceDate'"
-                                      [labelText]="'Invoice Date'"
-                                      [name]="'invoiceDate'"
-                                      calendarDateFormat="dd.mm.yy"
-                                      maxlength="10">
-            </app-validatable-calendar>
-          </div>
-        </div>
-      </div>
-      <div *ngIf="currentStatus.level > 1" class="p-col-12" style="margin-top: 15pt;">
-        <div [ngStyle]="editStyle(2)" class="p-grid">
-          <div class="p-col-6">
-            <app-validatable-dropdownlist (componentHasError)="setHasCreatorError($event)"
-                                          (ngModelChange)="onSupplierChanged($event)"
-                                          [idComponent]="'id-invoiceCreator'"
-                                          [labelText]="'Invoice creator person'"
-                                          [name]="'creator'"
-                                          [ngModel]="invoice.personSupplierId"
-                                          [optionList]="personInvoiceSupplier"
-                                          [placeholder]="'Select person'"
-                                          [txtMinLength]="-1">
-            </app-validatable-dropdownlist>
-          </div>
-          <div class="p-col-2" style="max-width: 50%;">
-            <p-button (onClick)="createInvoiceCreator()" label="Create"></p-button>
-          </div>
-        </div>
-      </div>
-      <div *ngIf="currentStatus.level > 2" class="p-col-12">
-        <div [ngStyle]="editStyle(3)" class="p-grid">
-          <div class="p-col-6">
-            <app-validatable-dropdownlist (componentHasError)="setHasRecipientError($event)"
-                                          [(ngModel)]="invoice.personRecipientId"
-                                          [idComponent]="'id-invoiceRecipient'"
-                                          [labelText]="'Invoice recipient person'"
-                                          [name]="'recipient'"
-                                          [optionList]="personInvoiceRecipient"
-                                          [placeholder]="'Select person'"
-                                          [txtMinLength]="0">
-            </app-validatable-dropdownlist>
-          </div>
-          <div class="p-col-2" style="max-width: 50%;">
-            <p-button (onClick)="createInvoiceRecipient()" label="Create"></p-button>
-          </div>
-        </div>
-      </div>
-      <div *ngIf="currentStatus.level > 3" [ngStyle]="editStyle(4)" class="p-col-12">
-        <app-invoice-items-table #itemsTableRef
-                                 (changeItemsEvent)="invoiceItemsChanges($event)"
-                                 (changeItemEvent)="itemValueChanged($event)"
-                                 (totalBruttoSumEvent)="invoice.totalSumBrutto=$event"
-                                 (totalNettoSumEvent)="invoice.totalSumNetto=$event"
-                                 [invoiceItems]="workflowInvoiceItems"
-                                 [modelChangedEvent]="eventsModelIsReset.asObservable()">
-
-        </app-invoice-items-table>
-      </div>
-      <div class="p-col-12">
-        <div class="p-grid">
-          <div *ngIf="currentStatus.level > 4" [ngStyle]="editStyle(5)" class="p-col-2">
-            <p-button (onClick)="saveInvoice($event)" [disabled]="haveErrors(workflowInvoiceItems)"
-                      label="Persist invoice"></p-button>
-          </div>
-        </div>
-      </div>
-      <div class="p-col-3">
-        <p-button (onClick)="movePreviousStep(currentStatus)" [disabled]="currentStatus.level < 1"
-                  icon="pi pi-fw pi-angle-double-left"
-                  title="Previous step"></p-button>
-        <p-button (onClick)="saveAndNext(currentStatus)" [disabled]="currentStatus.level > 4"
-                  icon="pi pi-fw pi-angle-double-right"
-                  title="Next step"></p-button>
-      </div>
-    </div>
-    </form>
-  </ng-template>
-</p-splitter>
--->

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/workflows/invoice-workflow/invoice-workflow.component.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/workflows/invoice-workflow/invoice-workflow.component.ts
@@ -33,6 +33,7 @@ import {
   ValidatableInputTextComponent
 } from "../../common-components/validatable-input-text/validatable-input-text.component";
 import {FloatLabel} from "primeng/floatlabel";
+import {TranslocoPipe} from "@jsverse/transloco";
 
 
 const CHECK_CIRCLE:string = "pi pi-check-circle"
@@ -41,7 +42,7 @@ const OFF_CIRCLE:string = "pi pi-circle-off"
 @Component({
   selector: 'app-invoice-workflow',
   standalone: true,
-  imports: [CommonModule, SplitterModule, TimelineModule, FormsModule, InputTextModule, ValidatableDropdownlistModule, ButtonModule, ValidatableCalendarModule, InvoiceFormModule, ValidatableInputTextComponent, FloatLabel],
+  imports: [CommonModule, SplitterModule, TimelineModule, FormsModule, InputTextModule, ValidatableDropdownlistModule, ButtonModule, ValidatableCalendarModule, InvoiceFormModule, ValidatableInputTextComponent, FloatLabel, TranslocoPipe],
   templateUrl: './invoice-workflow.component.html',
   styleUrls: ['./invoice-workflow.component.css']
 })

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/de/app.json
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/de/app.json
@@ -2,7 +2,30 @@
   "title": "Auftragsmanager",
   "menu": {
     "invoice": {
-      "create": "Rechnung erstellen"
-    }
+      "create": "Rechnung erstellen",
+      "title": "Rechnung",
+      "create_catalog_item": "Katalogposition erstellen",
+      "manage_catalog_items": "Katalogpositionen verwalten",
+      "management": "Rechnungsverwaltung",
+      "print": "Rechnung drucken"
+    },
+    "user_management": "Benutzerverwaltung",
+    "create_user": "Benutzer erstellen",
+    "person": {
+      "title": "Person",
+      "create": "Person erstellen",
+      "management": "Personenverwaltung"
+    },
+    "workflows": {
+      "title": "Workflows",
+      "create_invoice": "Rechnung erstellen"
+    },
+    "logout": "Abmelden"
+  },
+  "tooltips": {
+    "navigate_home": "Zur Startseite navigieren"
+  },
+  "homepage": {
+    "heading": "Startseite der Ordermanager-Anwendung"
   }
 }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/de/auth.json
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/de/auth.json
@@ -2,7 +2,16 @@
   "login": {
     "heading": "Bitte melden Sie sich im System an",
     "error": {
-      "invalid_credentials": "Bitte geben Sie korrekten Benutzernamen und Passwort ein."
+      "invalid_credentials": "Bitte geben Sie korrekten Benutzernamen und Passwort ein.",
+      "summary": "Anmeldefehler"
+    },
+    "fields": {
+      "username": "Benutzername",
+      "password": "Passwort"
+    },
+    "actions": {
+      "register": "Neuen Benutzer registrieren",
+      "login": "Anmelden"
     }
   }
 }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/de/common.json
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/de/common.json
@@ -1,32 +1,34 @@
 {
-  "actions": {
-    "save": "Speichern",
-    "cancel": "Abbrechen",
-    "find": "Suchen"
-  },
-  "dialog": {
-    "confirm": {
-      "yes": "Ja",
-      "no": "Nein"
+  "common": {
+    "actions": {
+      "save": "Speichern",
+      "cancel": "Abbrechen",
+      "find": "Suchen"
+    },
+    "dialog": {
+      "confirm": {
+        "yes": "Ja",
+        "no": "Nein"
+      }
+    },
+    "validation": {
+      "required": "Feld ist erforderlich.",
+      "min_length": "Mindestlänge ist {{min}}.",
+      "date_required": "Datum ist erforderlich",
+      "start_before_end": "Startdatum muss vor Enddatum liegen"
+    },
+    "datePeriod": {
+      "title": "Datumsbereich auswählen",
+      "startDate": "Startdatum",
+      "endDate": "Enddatum"
+    },
+    "table": {
+      "manage": "Verwalten"
+    },
+    "tooltips": {
+      "delete_item": "Eintrag löschen",
+      "edit_item": "Eintrag bearbeiten",
+      "rollback_item": "Änderung zurücksetzen"
     }
-  },
-  "validation": {
-    "required": "Feld ist erforderlich.",
-    "min_length": "Mindestlänge ist {{min}}.",
-    "date_required": "Datum ist erforderlich",
-    "start_before_end": "Startdatum muss vor Enddatum liegen"
-  },
-  "datePeriod": {
-    "title": "Datumsbereich auswählen",
-    "startDate": "Startdatum",
-    "endDate": "Enddatum"
-  },
-  "table": {
-    "manage": "Verwalten"
-  },
-  "tooltips": {
-    "delete_item": "Eintrag löschen",
-    "edit_item": "Eintrag bearbeiten",
-    "rollback_item": "Änderung zurücksetzen"
   }
 }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/de/common.json
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/de/common.json
@@ -12,6 +12,21 @@
   },
   "validation": {
     "required": "Feld ist erforderlich.",
-    "min_length": "Mindestlänge ist {{min}}."
+    "min_length": "Mindestlänge ist {{min}}.",
+    "date_required": "Datum ist erforderlich",
+    "start_before_end": "Startdatum muss vor Enddatum liegen"
+  },
+  "datePeriod": {
+    "title": "Datumsbereich auswählen",
+    "startDate": "Startdatum",
+    "endDate": "Enddatum"
+  },
+  "table": {
+    "manage": "Verwalten"
+  },
+  "tooltips": {
+    "delete_item": "Eintrag löschen",
+    "edit_item": "Eintrag bearbeiten",
+    "rollback_item": "Änderung zurücksetzen"
   }
 }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/de/invoice.json
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/de/invoice.json
@@ -6,5 +6,28 @@
     "header": {
       "amount": "Menge"
     }
+  },
+  "management": {
+    "title": "Rechnungsverwaltung",
+    "confirm": {
+      "delete": "Löschen der Rechnung bestätigen",
+      "delete_message": "Möchten Sie die Rechnung wirklich dauerhaft löschen?",
+      "save_message": "Möchten Sie die Änderungen an Rechnungen wirklich dauerhaft speichern?"
+    },
+    "tooltips": {
+      "edit_invoice": "Doppelklick, um Rechnung zu bearbeiten"
+    },
+    "table": {
+      "invoice_number": "Rechnungsnummer",
+      "supplier": "Lieferant",
+      "recipient": "Empfänger",
+      "invoice_date": "Rechnungsdatum",
+      "creation_date": "Rechnungserstellungsdatum",
+      "netto_sum": "Nettosumme",
+      "brutto_sum": "Bruttosumme"
+    }
+  },
+  "table_cell": {
+    "download": "Herunterladen"
   }
 }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/de/invoice.json
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/de/invoice.json
@@ -7,27 +7,53 @@
       "amount": "Menge"
     }
   },
-  "management": {
-    "title": "Rechnungsverwaltung",
-    "confirm": {
-      "delete": "Löschen der Rechnung bestätigen",
-      "delete_message": "Möchten Sie die Rechnung wirklich dauerhaft löschen?",
-      "save_message": "Möchten Sie die Änderungen an Rechnungen wirklich dauerhaft speichern?"
-    },
-    "tooltips": {
-      "edit_invoice": "Doppelklick, um Rechnung zu bearbeiten"
-    },
-    "table": {
-      "invoice_number": "Rechnungsnummer",
-      "supplier": "Lieferant",
-      "recipient": "Empfänger",
-      "invoice_date": "Rechnungsdatum",
-      "creation_date": "Rechnungserstellungsdatum",
-      "netto_sum": "Nettosumme",
-      "brutto_sum": "Bruttosumme"
-    }
-  },
   "table_cell": {
     "download": "Herunterladen"
+  },
+  "invoice": {
+    "number": "Rechnungsnummer",
+    "description": "Beschreibung",
+    "rate_type": "Rechnungstyp",
+    "total_netto": "Gesamtnetto",
+    "total_brutto": "Gesamtbrutto",
+    "add_item": "Element hinzufügen",
+    "person_creator": "Ersteller der Rechnung",
+    "person_recipient": "Empfänger der Rechnung",
+    "creation_date": "Erstellungsdatum",
+    "invoice_date": "Rechnungsdatum",
+    "management": {
+      "title": "Rechnungsverwaltung",
+      "confirm": {
+        "delete": "Löschen der Rechnung bestätigen",
+        "delete_message": "Möchten Sie die Rechnung wirklich dauerhaft löschen?",
+        "save_message": "Möchten Sie die Änderungen an Rechnungen wirklich dauerhaft speichern?"
+      },
+      "tooltips": {
+        "edit_invoice": "Doppelklick, um Rechnung zu bearbeiten"
+      },
+      "table": {
+        "invoice_number": "Rechnungsnummer",
+        "supplier": "Lieferant",
+        "recipient": "Empfänger",
+        "invoice_date": "Rechnungsdatum",
+        "creation_date": "Rechnungserstellungsdatum",
+        "netto_sum": "Nettosumme",
+        "brutto_sum": "Bruttosumme"
+      }
+    },
+    "item": {
+      "manage": {
+        "catalog_items": "Verwaltung von Katalogelemente"
+      },
+      "table": {
+        "item_name": "Elementname",
+        "short_description": "Kurzbeschreibung",
+        "price": "Elementpreis",
+        "vat": "MwSt%",
+        "amount": "Menge",
+        "sum_netto": "Nettosumme",
+        "sum_brutto": "Bruttosumme"
+      }
+    }
   }
 }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/de/person.json
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/de/person.json
@@ -3,5 +3,23 @@
     "field": {
       "first_name": "Vorname"
     }
+  },
+  "management": {
+    "title": "Personenverwaltung",
+    "tooltips": {
+      "edit_person": "Doppelklick, um Person zu bearbeiten"
+    },
+    "confirm": {
+      "delete": "Löschen der Person bestätigen",
+      "delete_message": "Sind Sie sicher, dass Sie die Person löschen möchten?"
+    },
+    "table": {
+      "last_name": "Nachname",
+      "first_name": "Vorname",
+      "company_name": "Firmenname",
+      "person_type": "Personentyp",
+      "tax_number": "Steuernummer",
+      "email": "E-Mail"
+    }
   }
 }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/de/person.json
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/de/person.json
@@ -1,25 +1,47 @@
 {
-  "form": {
-    "field": {
-      "first_name": "Vorname"
-    }
-  },
-  "management": {
-    "title": "Personenverwaltung",
-    "tooltips": {
-      "edit_person": "Doppelklick, um Person zu bearbeiten"
+  "person": {
+    "save_and_return": "Speichern und zurückkehren",
+    "dialog": {
+      "edit_person": "Person bearbeiten"
     },
-    "confirm": {
-      "delete": "Löschen der Person bestätigen",
-      "delete_message": "Sind Sie sicher, dass Sie die Person löschen möchten?"
+    "form": {
+      "create_person": "Neue Person anlegen",
+      "person_address": "Adresse der Person",
+      "person_bank": "Bankverbindung der Person",
+      "field": {
+        "first_name": "Vorname",
+        "last_name": "Nachname",
+        "email": "E-Mail",
+        "company_name": "Firmenname",
+        "tax_number": "Steuernummer",
+        "zip": "Postleitzahl",
+        "city": "Ort",
+        "postbox": "Postfach",
+        "street": "Strasse",
+        "bank": "Bankname",
+        "account": "Kontonummer",
+        "iban": "IBAN",
+        "bic_swift": "BIC/SWIFT",
+        "wrong_iban_format": "Ungültiges IBAN-Format"
+      }
     },
-    "table": {
-      "last_name": "Nachname",
-      "first_name": "Vorname",
-      "company_name": "Firmenname",
-      "person_type": "Personentyp",
-      "tax_number": "Steuernummer",
-      "email": "E-Mail"
+    "management": {
+      "title": "Personenverwaltung",
+      "tooltips": {
+        "edit_person": "Doppelklick, um Person zu bearbeiten"
+      },
+      "confirm": {
+        "delete": "Löschen der Person bestätigen",
+        "delete_message": "Sind Sie sicher, dass Sie die Person löschen möchten?"
+      },
+      "table": {
+        "last_name": "Nachname",
+        "first_name": "Vorname",
+        "company_name": "Firmenname",
+        "person_type": "Personentyp",
+        "tax_number": "Steuernummer",
+        "email": "E-Mail"
+      }
     }
   }
 }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/en/app.json
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/en/app.json
@@ -2,7 +2,30 @@
   "title": "Order manager",
   "menu": {
     "invoice": {
-      "create": "Create invoice"
-    }
+      "create": "Create invoice",
+      "title": "Invoice",
+      "create_catalog_item": "Create catalog item",
+      "manage_catalog_items": "Manage catalog items",
+      "management": "Invoice management",
+      "print": "Print invoice"
+    },
+    "user_management": "User management",
+    "create_user": "Create user",
+    "person": {
+      "title": "Person",
+      "create": "Create Person",
+      "management": "Person management"
+    },
+    "workflows": {
+      "title": "Workflows",
+      "create_invoice": "Create invoice"
+    },
+    "logout": "Logout"
+  },
+  "tooltips": {
+    "navigate_home": "Navigate to home page"
+  },
+  "homepage": {
+    "heading": "Homepage of Ordermanager Application"
   }
 }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/en/auth.json
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/en/auth.json
@@ -2,7 +2,16 @@
   "login": {
     "heading": "Please login to the system",
     "error": {
-      "invalid_credentials": "Please enter correct user name and password."
+      "invalid_credentials": "Please enter correct user name and password.",
+      "summary": "Login error"
+    },
+    "fields": {
+      "username": "User name",
+      "password": "Password"
+    },
+    "actions": {
+      "register": "Register new user",
+      "login": "Login"
     }
   }
 }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/en/common.json
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/en/common.json
@@ -12,6 +12,21 @@
   },
   "validation": {
     "required": "Field is required.",
-    "min_length": "Minimum length is {{min}}."
+    "min_length": "Minimum length is {{min}}.",
+    "date_required": "Date is required",
+    "start_before_end": "Start date must be before end date"
+  },
+  "datePeriod": {
+    "title": "Select date period",
+    "startDate": "Start Date",
+    "endDate": "End Date"
+  },
+  "table": {
+    "manage": "Manage"
+  },
+  "tooltips": {
+    "delete_item": "Delete item",
+    "edit_item": "Edit item",
+    "rollback_item": "Rollback item"
   }
 }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/en/common.json
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/en/common.json
@@ -1,32 +1,34 @@
 {
-  "actions": {
-    "save": "Save",
-    "cancel": "Cancel",
-    "find": "Find"
-  },
-  "dialog": {
-    "confirm": {
-      "yes": "Yes",
-      "no": "No"
+  "common": {
+    "actions": {
+      "save": "Save",
+      "cancel": "Cancel",
+      "find": "Find"
+    },
+    "dialog": {
+      "confirm": {
+        "yes": "Yes",
+        "no": "No"
+      }
+    },
+    "validation": {
+      "required": "Field is required.",
+      "min_length": "Minimum length is {{min}}.",
+      "date_required": "Date is required",
+      "start_before_end": "Start date must be before end date"
+    },
+    "datePeriod": {
+      "title": "Select date period",
+      "startDate": "Start Date",
+      "endDate": "End Date"
+    },
+    "table": {
+      "manage": "Manage"
+    },
+    "tooltips": {
+      "delete_item": "Delete item",
+      "edit_item": "Edit item",
+      "rollback_item": "Rollback item"
     }
-  },
-  "validation": {
-    "required": "Field is required.",
-    "min_length": "Minimum length is {{min}}.",
-    "date_required": "Date is required",
-    "start_before_end": "Start date must be before end date"
-  },
-  "datePeriod": {
-    "title": "Select date period",
-    "startDate": "Start Date",
-    "endDate": "End Date"
-  },
-  "table": {
-    "manage": "Manage"
-  },
-  "tooltips": {
-    "delete_item": "Delete item",
-    "edit_item": "Edit item",
-    "rollback_item": "Rollback item"
   }
 }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/en/invoice.json
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/en/invoice.json
@@ -7,27 +7,53 @@
       "amount": "Amount"
     }
   },
-  "management": {
-    "title": "Invoice management",
-    "confirm": {
-      "delete": "Confirm delete invoice",
-      "delete_message": "Are you really want to permanently delete invoice?",
-      "save_message": "Are you really want to permanently save changes in invoices"
-    },
-    "tooltips": {
-      "edit_invoice": "Double click to edit invoice"
-    },
-    "table": {
-      "invoice_number": "Invoice number",
-      "supplier": "Supplier",
-      "recipient": "Recipient",
-      "invoice_date": "Invoice date",
-      "creation_date": "Invoice creation date",
-      "netto_sum": "Netto sum",
-      "brutto_sum": "Brutto sum"
-    }
-  },
   "table_cell": {
     "download": "Download"
+  },
+  "invoice": {
+    "number": "Invoice number",
+    "description": "Beschreibung",
+    "rate_type": "Invoice type",
+    "total_netto": "Total netto",
+    "total_brutto": "Total brutto",
+    "add_item": "Add Item",
+    "person_creator": "Invoice creator person",
+    "person_recipient": "Invoice recipient person",
+    "creation_date": "Creation date",
+    "invoice_date": "Invoice date",
+    "management": {
+      "title": "Invoice management",
+      "confirm": {
+        "delete": "Confirm delete invoice",
+        "delete_message": "Are you really want to permanently delete invoice?",
+        "save_message": "Are you really want to permanently save changes in invoices"
+      },
+      "tooltips": {
+        "edit_invoice": "Double click to edit invoice"
+      },
+      "table": {
+        "invoice_number": "Invoice number",
+        "supplier": "Supplier",
+        "recipient": "Recipient",
+        "invoice_date": "Invoice date",
+        "creation_date": "Invoice creation date",
+        "netto_sum": "Netto sum",
+        "brutto_sum": "Brutto sum"
+      }
+    },
+    "item": {
+      "manage": {
+        "catalog_items": "Manage with catalog items"
+      },
+      "table": {
+        "item_name": "Item name",
+        "short_description": "Short description",
+        "price": "Item price",
+        "vat": "MwSt%",
+        "amount": "Amount",
+        "sum_netto": "Sum netto",
+        "sum_brutto": "Sum brutto"
+      }
+    }
   }
 }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/en/invoice.json
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/en/invoice.json
@@ -6,5 +6,28 @@
     "header": {
       "amount": "Amount"
     }
+  },
+  "management": {
+    "title": "Invoice management",
+    "confirm": {
+      "delete": "Confirm delete invoice",
+      "delete_message": "Are you really want to permanently delete invoice?",
+      "save_message": "Are you really want to permanently save changes in invoices"
+    },
+    "tooltips": {
+      "edit_invoice": "Double click to edit invoice"
+    },
+    "table": {
+      "invoice_number": "Invoice number",
+      "supplier": "Supplier",
+      "recipient": "Recipient",
+      "invoice_date": "Invoice date",
+      "creation_date": "Invoice creation date",
+      "netto_sum": "Netto sum",
+      "brutto_sum": "Brutto sum"
+    }
+  },
+  "table_cell": {
+    "download": "Download"
   }
 }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/en/person.json
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/en/person.json
@@ -1,25 +1,47 @@
 {
-  "form": {
-    "field": {
-      "first_name": "First name"
-    }
-  },
-  "management": {
-    "title": "Person management",
-    "tooltips": {
-      "edit_person": "Double click to edit person"
+  "person": {
+    "save_and_return": "Save and return",
+    "dialog": {
+      "edit_person": "Person bearbeiten"
     },
-    "confirm": {
-      "delete": "Confirm delete person",
-      "delete_message": "Are you sure you want to delete the person?"
+    "form": {
+      "create_person": "Create person",
+      "person_address": "Person address",
+      "person_bank": "Bankverbindung der Person",
+      "field": {
+        "first_name": "First name",
+        "last_name": "Las name",
+        "email": "Email",
+        "company_name": "Company name",
+        "tax_number": "Tax number",
+        "zip": "Zip",
+        "city": "City",
+        "postbox": "Post box",
+        "street": "Street",
+        "bank": "Bank name",
+        "account": "Account number",
+        "iban": "IBAN",
+        "bic_swift": "BIC/SWIFT",
+        "wrong_iban_format": "Wrong IBAN format"
+      }
     },
-    "table": {
-      "last_name": "Person last name",
-      "first_name": "Person first name",
-      "company_name": "Company name",
-      "person_type": "Person type",
-      "tax_number": "Tax number",
-      "email": "E-mail"
+    "management": {
+      "title": "Person management",
+      "tooltips": {
+        "edit_person": "Double click to edit person"
+      },
+      "confirm": {
+        "delete": "Confirm delete person",
+        "delete_message": "Are you sure you want to delete the person?"
+      },
+      "table": {
+        "last_name": "Person last name",
+        "first_name": "Person first name",
+        "company_name": "Company name",
+        "person_type": "Person type",
+        "tax_number": "Tax number",
+        "email": "E-mail"
+      }
     }
   }
 }

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/en/person.json
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/assets/i18n/en/person.json
@@ -3,5 +3,23 @@
     "field": {
       "first_name": "First name"
     }
+  },
+  "management": {
+    "title": "Person management",
+    "tooltips": {
+      "edit_person": "Double click to edit person"
+    },
+    "confirm": {
+      "delete": "Confirm delete person",
+      "delete_message": "Are you sure you want to delete the person?"
+    },
+    "table": {
+      "last_name": "Person last name",
+      "first_name": "Person first name",
+      "company_name": "Company name",
+      "person_type": "Person type",
+      "tax_number": "Tax number",
+      "email": "E-mail"
+    }
   }
 }


### PR DESCRIPTION
### Motivation
- Replace scattered hardcoded user-facing text in the invoices frontend with a Transloco-based i18n solution to enable English/German translations and consistent key usage.
- Keep changes minimal and safe so existing templates and TypeScript logic continue to work while preparing for further i18n cleanup.

### Description
- Added a multi-file JSON Transloco loader and provider (`transloco/transloco-loader.ts`, `transloco/transloco.providers.ts`) and wired `TranslocoModule` and providers into `AppModule` to load `app`, `auth`, `common`, `invoice`, `person`, `workflow` scopes.
- Replaced hardcoded template strings with the Transloco pipe (`| transloco`) for headings, table headers, button labels, tooltips and validation messages across core components including app shell, login, date-period finder, confirmation dialog, validation components, invoice management, person management and the table-cell renderer.
- Replaced TypeScript user-facing strings (menu labels, login toast summary/detail, and confirmation-message fields) to use `TranslocoService.translate(...)` where values are created in code at runtime.
- Added/extended translation keys in both English and German JSON assets under `src/assets/i18n/{en,de}/` (`app.json`, `auth.json`, `common.json`, `invoice.json`, `person.json`) to cover the migrated strings and parameterized validations.

### Testing
- Attempted `npm run build` (Angular CLI `ng` not available in the environment), so a full Angular build could not be executed and therefore could not be validated here.
- Validated updated translation JSON files for syntax correctness using `python -m json.tool` which succeeded for the modified JSON files.
- Commit recorded with the migration changes; automated JSON validation passed but runtime/integration verification requires an Angular build and runtime smoke test in a proper dev environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d90ddd1fb8832b9f711c534f444674)