### PR TITLE
Fix Transloco root provider configuration in NgModule app

### DIFF
--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/transloco/transloco.providers.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/transloco/transloco.providers.ts
@@ -1,23 +1,15 @@
-import { Provider } from '@angular/core';
-import {
-  TRANSLOCO_CONFIG,
-  TRANSLOCO_LOADER,
-  translocoConfig,
-} from '@jsverse/transloco';
+import { provideTransloco, translocoConfig } from '@jsverse/transloco';
 import { MultiJsonTranslocoHttpLoader } from './transloco-loader';
+import { environment } from '../../environments/environment';
 
-export const translocoProviders: Provider[] = [
-  {
-    provide: TRANSLOCO_CONFIG,
-    useValue: translocoConfig({
+export const translocoProviders = [
+  provideTransloco({
+    config: translocoConfig({
       availableLangs: ['en', 'de'],
       defaultLang: 'en',
       reRenderOnLangChange: true,
-      prodMode: false,
+      prodMode: environment.production,
     }),
-  },
-  {
-    provide: TRANSLOCO_LOADER,
-    useClass: MultiJsonTranslocoHttpLoader,
-  },
+    loader: MultiJsonTranslocoHttpLoader,
+  }),
 ];


### PR DESCRIPTION
### Motivation
- The app bootstraps an `AppModule` (NgModule-based) but the previous Transloco setup only provided `TRANSLOCO_CONFIG` and `TRANSLOCO_LOADER`, which led to a missing internal provider (`TRANSLOCO_TRANSPILER`) at runtime.
- Restore a single, complete root-level Transloco registration so `TranslocoService` and all internal providers (transpiler, handler graph) are available to feature modules without redefining root providers.
- Keep existing i18n migration choices (available langs, default lang, custom loader and file layout) while making the minimal safe changes.

### Description
- Detected the app is NgModule-based (bootstraps `AppModule`) and left `AppModule` bootstrapping and `TranslocoModule` imports in feature modules unchanged.
- Replaced the manual provider array in `src/app/transloco/transloco.providers.ts` with a single `provideTransloco({...})` call to register the complete Transloco provider graph.
- Kept the custom loader by wiring `loader: MultiJsonTranslocoHttpLoader` and preserved languages and behavior while switching `prodMode` to use `environment.production`.
- Verified the translation loader path remains `assets/i18n/${lang}/${scope}.json`, which matches the files under `src/assets/i18n/en` and `src/assets/i18n/de`.

### Testing
- Ran `npm run build` in `ordermanager-ui/ui/resources/frontend/invoices` to validate the change, but the build could not run in this environment because the Angular CLI (`ng`) is not installed (`sh: 1: ng: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91a895c68832b93cd3a6525e665ca)