### PR TITLE
Fix Transloco key prefixes in AppComponent (remove incorrect `app.` namespace)

### DIFF
--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/app.component.html
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/app.component.html
@@ -1,9 +1,9 @@
 @if (!isAuthenticated()) {
 <div  class="p-grid  app_title p-shadow-4">
   <!--  <p-button  label="Home" (click)="router.navigateByUrl('/')"></p-button>-->
-  <a (click)="router.navigateByUrl('/')" [pTooltip]="'app.tooltips.navigate_home' | transloco" [tooltipPosition]="'right'"><img
+  <a (click)="router.navigateByUrl('/')" [pTooltip]="'tooltips.navigate_home' | transloco" [tooltipPosition]="'right'"><img
     src="assets/home-small.png"></a>
-  <h3 style="margin-left: 5pt;">{{ 'app.title' | transloco }}</h3>
+  <h3 style="margin-left: 5pt;">{{ 'title' | transloco }}</h3>
 
 </div>
   <app-user-login></app-user-login>
@@ -12,7 +12,7 @@
   <div class="nav_app_cls p-grid p-shadow-4">
     <nav style="margin-bottom: 10pt;">
       <div class="p-grid">
-        <a (click)="router.navigateByUrl('/')" [pTooltip]="'app.tooltips.navigate_home' | transloco"
+        <a (click)="router.navigateByUrl('/')" [pTooltip]="'tooltips.navigate_home' | transloco"
            [tooltipPosition]="'right'" style="margin-right: 10pt; margin-top: 8pt;margin-left: 10pt;"><img
           src="assets/home-small.png"></a>
         <p-menubar [model]="menuItems"></p-menubar>
@@ -20,7 +20,7 @@
     </nav>
   </div>
   <div *ngIf="this.router.url ==='/'" style="margin: 10pt 10pt 10pt 10pt;">
-    <h2>{{ 'app.homepage.heading' | transloco }}</h2>
+    <h2>{{ 'homepage.heading' | transloco }}</h2>
   </div>
   <br/>
 </div>

--- a/ordermanager-ui/ui/resources/frontend/invoices/src/app/app.component.ts
+++ b/ordermanager-ui/ui/resources/frontend/invoices/src/app/app.component.ts
@@ -29,40 +29,40 @@ export class AppComponent implements OnInit, AfterViewInit {
 
     this.menuItems = [
       {
-        label: this.translocoService.translate('app.menu.user_management'),
+        label: this.translocoService.translate('menu.user_management'),
         icon: 'pi pi-fw pi-users',
         items: [
-          {label: this.translocoService.translate('app.menu.create_user'), icon: 'pi pi-fw pi-user-plus', routerLink: '/user-registration-page'}
+          {label: this.translocoService.translate('menu.create_user'), icon: 'pi pi-fw pi-user-plus', routerLink: '/user-registration-page'}
         ]
       },
       {
-        label: this.translocoService.translate('app.menu.invoice.title'),
+        label: this.translocoService.translate('menu.invoice.title'),
         icon: 'pi pi-fw pi-book',
         items: [
-          {label: this.translocoService.translate('app.menu.invoice.create'), icon: 'pi pi-fw pi-plus', routerLink: '/create-invoice-page'},
-          {label: this.translocoService.translate('app.menu.invoice.create_catalog_item'), icon: 'pi pi-fw pi-plus', routerLink: '/create-invoice-item-page'},
-          {label: this.translocoService.translate('app.menu.invoice.manage_catalog_items'), icon: 'pi pi-fw pi-pencil', routerLink: '/catalog-item-management-page'},
-          {label: this.translocoService.translate('app.menu.invoice.management'), icon: 'pi pi-fw pi-pencil', routerLink: '/invoice-management_page'},
-          {label: this.translocoService.translate('app.menu.invoice.print'), icon: 'pi pi-fw pi-file-pdf', routerLink: '/invoice-list_page'}
+          {label: this.translocoService.translate('menu.invoice.create'), icon: 'pi pi-fw pi-plus', routerLink: '/create-invoice-page'},
+          {label: this.translocoService.translate('menu.invoice.create_catalog_item'), icon: 'pi pi-fw pi-plus', routerLink: '/create-invoice-item-page'},
+          {label: this.translocoService.translate('menu.invoice.manage_catalog_items'), icon: 'pi pi-fw pi-pencil', routerLink: '/catalog-item-management-page'},
+          {label: this.translocoService.translate('menu.invoice.management'), icon: 'pi pi-fw pi-pencil', routerLink: '/invoice-management_page'},
+          {label: this.translocoService.translate('menu.invoice.print'), icon: 'pi pi-fw pi-file-pdf', routerLink: '/invoice-list_page'}
         ]
       },
       {
-        label: this.translocoService.translate('app.menu.person.title'),
+        label: this.translocoService.translate('menu.person.title'),
         icon: 'pi pi-fw pi-user',
         items: [
-          {label: this.translocoService.translate('app.menu.person.create'), icon: 'pi pi-fw pi-plus', routerLink: '/create-person_page'},
-          {label: this.translocoService.translate('app.menu.person.management'), icon: 'pi pi-fw pi-pencil', routerLink: '/person-management-page'}
+          {label: this.translocoService.translate('menu.person.create'), icon: 'pi pi-fw pi-plus', routerLink: '/create-person_page'},
+          {label: this.translocoService.translate('menu.person.management'), icon: 'pi pi-fw pi-pencil', routerLink: '/person-management-page'}
         ]
       },
       {
-        label: this.translocoService.translate('app.menu.workflows.title'),
+        label: this.translocoService.translate('menu.workflows.title'),
         icon: 'pi pi-fw pi-book',
         items: [
-          {label: this.translocoService.translate('app.menu.workflows.create_invoice'), icon: 'pi pi-fw pi-plus', routerLink: '/workflow-create-invoice'},
+          {label: this.translocoService.translate('menu.workflows.create_invoice'), icon: 'pi pi-fw pi-plus', routerLink: '/workflow-create-invoice'},
         ]
       },
       {
-        label: this.translocoService.translate('app.menu.logout'),
+        label: this.translocoService.translate('menu.logout'),
         icon: 'pi pi-fw pi-sign-out',
         command: () => this.appSecurityService.logout()
       }


### PR DESCRIPTION
### Motivation
- The UI was requesting translation keys with an `app.` prefix even though the loader merges `app.json` into the root translation object, so keys should be used without the `app.` namespace to match the actual JSON structure.

### Description
- Updated `ordermanager-ui/ui/resources/frontend/invoices/src/app/app.component.html` to use `title`, `tooltips.navigate_home` and `homepage.heading` instead of `app.title`, `app.tooltips.navigate_home` and `app.homepage.heading`.
- Updated `ordermanager-ui/ui/resources/frontend/invoices/src/app/app.component.ts` to remove the `app.` prefix from all menu translations (e.g. `app.menu.user_management` → `menu.user_management`, `app.menu.invoice.*` → `menu.invoice.*`, `app.menu.person.*` → `menu.person.*`, `app.menu.workflows.*` → `menu.workflows.*`, `app.menu.logout` → `menu.logout`).
- The transloco loader (`src/app/transloco/transloco-loader.ts`) loads `assets/i18n/{lang}/app.json` and merges its keys into the root translation object rather than namespacing under `app`, so code was aligned to the loader behavior.
- Confirmed `en/app.json` and `de/app.json` share the same root key structure (`title`, `menu.*`, `tooltips.*`, `homepage.*`) and no structural changes were made to translation files.

### Testing
- Ran a repository search with `rg` to find remaining `app.` translation usages and confirmed there are no remaining `translate('app...')` or `'app...' | transloco` occurrences in `src/app` (success).
- Ran a key-existence check script that verifies all keys referenced by `AppComponent` exist in both `src/assets/i18n/en/app.json` and `src/assets/i18n/de/app.json` and observed no missing keys (success).
- Ran a script to compare leaf-key sets across `en/*.json` and `de/*.json` and confirmed structures match for `app.json` and the other scope files (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91ec57544832b9f130b9377222bcb)