### PR TITLE
Fix JasperReports i18n keys rendered as literal text in invoice JRXML templates

### DIFF
--- a/ordermanager-backend/src/main/resources/invoice-data.jrxml
+++ b/ordermanager-backend/src/main/resources/invoice-data.jrxml
@@ -81,13 +81,13 @@
 					<jr:column width="274" uuid="dbad66f9-7b70-42a5-a4e7-7d29f3230a19">
 						<property name="com.jaspersoft.studio.components.table.model.column.name" value="Column1"/>
 						<jr:columnHeader style="Table_CH" height="30" rowSpan="1">
-							<staticText>
+							<textField>
 								<reportElement x="0" y="0" width="274" height="30" uuid="8d67abdb-a89c-4d8c-936b-dadaf442bf11"/>
 								<textElement textAlignment="Center" verticalAlignment="Middle">
 									<font size="10" isBold="true"/>
 								</textElement>
-								<text><![CDATA[$R{item.description}]]></text>
-							</staticText>
+								<textFieldExpression><![CDATA[$R{item.description}]]></textFieldExpression>
+							</textField>
 						</jr:columnHeader>
 						<jr:detailCell style="Table_TD" height="30">
 							<textField>
@@ -151,13 +151,13 @@
 					<jr:column width="60" uuid="2b98cead-4ceb-49d5-b409-400ab9cb184c">
 						<property name="com.jaspersoft.studio.components.table.model.column.name" value="Column4"/>
 						<jr:columnHeader style="Table_CH" height="30" rowSpan="1">
-							<staticText>
+							<textField>
 								<reportElement x="0" y="0" width="60" height="30" uuid="732cec0b-1bb1-44bf-b313-58a0e7e9b2c0"/>
 								<textElement textAlignment="Center" verticalAlignment="Middle">
 									<font fontName="SansSerif" size="10" isBold="true"/>
 								</textElement>
-								<text><![CDATA[$R{sum.net}]]></text>
-							</staticText>
+								<textFieldExpression><![CDATA[$R{sum.net}]]></textFieldExpression>
+							</textField>
 						</jr:columnHeader>
 						<jr:detailCell style="Table_TD" height="30">
 							<textField pattern="#0.00">
@@ -174,13 +174,13 @@
 					<jr:column width="60" uuid="132380e0-77ce-48db-a0cf-5a2aaccde870">
 						<property name="com.jaspersoft.studio.components.table.model.column.name" value="Column5"/>
 						<jr:columnHeader style="Table_CH" height="30" rowSpan="1">
-							<staticText>
+							<textField>
 								<reportElement x="0" y="0" width="60" height="30" uuid="b7b7b7e9-fe50-45bb-97f0-5c5a3edfc0d2"/>
 								<textElement textAlignment="Center" verticalAlignment="Middle">
 									<font size="10" isBold="true"/>
 								</textElement>
-								<text><![CDATA[$R{vat.percent}]]></text>
-							</staticText>
+								<textFieldExpression><![CDATA[$R{vat.percent}]]></textFieldExpression>
+							</textField>
 						</jr:columnHeader>
 						<jr:detailCell style="Table_TD" height="30">
 							<textField pattern="#0.00">
@@ -197,13 +197,13 @@
 					<jr:column width="60" uuid="ba9da673-9fe7-4ac4-9a5b-b279c2ab4c2f">
 						<property name="com.jaspersoft.studio.components.table.model.column.name" value="Column6"/>
 						<jr:columnHeader style="Table_CH" height="30" rowSpan="1">
-							<staticText>
+							<textField>
 								<reportElement x="0" y="0" width="60" height="30" uuid="1ec901d9-fa4c-46c8-ab13-9c2d3fd30837"/>
 								<textElement textAlignment="Center" verticalAlignment="Middle">
 									<font size="10" isBold="true"/>
 								</textElement>
-								<text><![CDATA[$R{sum.gross}]]></text>
-							</staticText>
+								<textFieldExpression><![CDATA[$R{sum.gross}]]></textFieldExpression>
+							</textField>
 						</jr:columnHeader>
 						<jr:detailCell style="Table_TD" height="30">
 							<textField pattern="###0.00">
@@ -235,13 +235,13 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$V{tottalNettoSum}]]></textFieldExpression>
 			</textField>
-			<staticText>
+			<textField>
 				<reportElement x="344" y="3" width="162" height="18" uuid="8cc5316f-3a4e-4cbb-ac71-93c5df5ee264">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 				</reportElement>
 				<textElement textAlignment="Right"/>
-				<text><![CDATA[$R{invoice.amount.net}]]></text>
-			</staticText>
+				<textFieldExpression><![CDATA[$R{invoice.amount.net}]]></textFieldExpression>
+			</textField>
 			<textField pattern="#0.00">
 				<reportElement x="505" y="21" width="50" height="18" uuid="98e09660-349e-4a7f-a616-6d9e9e45018a">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
@@ -253,13 +253,13 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$V{totalVat}]]></textFieldExpression>
 			</textField>
-			<staticText>
+			<textField>
 				<reportElement x="385" y="22" width="121" height="18" uuid="80496afc-a08f-472c-9f42-bad04c399ebb">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 				</reportElement>
 				<textElement textAlignment="Right"/>
-				<text><![CDATA[$R{invoice.vat}]]></text>
-			</staticText>
+				<textFieldExpression><![CDATA[$R{invoice.vat}]]></textFieldExpression>
+			</textField>
 			<textField pattern="#0.00">
 				<reportElement x="505" y="41" width="50" height="21" uuid="2434919a-0886-44fb-8809-e6243bd1af7f">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
@@ -272,7 +272,7 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$V{totalBruttoSum}]]></textFieldExpression>
 			</textField>
-			<staticText>
+			<textField>
 				<reportElement x="334" y="42" width="173" height="21" uuid="af4414db-8471-4f23-941e-1bac638fb54e">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
@@ -280,8 +280,8 @@
 				<textElement textAlignment="Right">
 					<font size="12" isBold="true"/>
 				</textElement>
-				<text><![CDATA[$R{invoice.amount.total}]]></text>
-			</staticText>
+				<textFieldExpression><![CDATA[$R{invoice.amount.total}]]></textFieldExpression>
+			</textField>
 			<textField>
 				<reportElement x="5" y="80" width="551" height="20" uuid="b4aa9ff2-d6b6-4f43-be1e-bd93772c3dce">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>

--- a/ordermanager-backend/src/main/resources/invoice.jrxml
+++ b/ordermanager-backend/src/main/resources/invoice.jrxml
@@ -39,13 +39,13 @@
 	</title>
 	<pageHeader>
 		<band height="207" splitType="Stretch">
-			<staticText>
+			<textField>
 				<reportElement x="160" y="-30" width="127" height="26" uuid="637a0830-b516-4bca-8724-05e866208cb1"/>
 				<textElement>
 					<font size="16" isBold="true"/>
 				</textElement>
-				<text><![CDATA[$R{invoice.title}]]></text>
-			</staticText>
+				<textFieldExpression><![CDATA[$R{invoice.title}]]></textFieldExpression>
+			</textField>
 			<textField>
 				<reportElement key="" x="51" y="30" width="210" height="25" uuid="1531119b-8e3b-4470-82c4-b28a5c502fbd">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
@@ -147,12 +147,12 @@
 				</reportElement>
 				<textFieldExpression><![CDATA[$F{recipientCity}]]></textFieldExpression>
 			</textField>
-			<staticText>
+			<textField>
 				<reportElement x="0" y="171" width="40" height="14" uuid="48b1c005-98ed-4b9d-8ad1-b09f85c962da">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 				</reportElement>
-				<text><![CDATA[$R{project.label}]]></text>
-			</staticText>
+				<textFieldExpression><![CDATA[$R{project.label}]]></textFieldExpression>
+			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement x="49" y="171" width="334" height="14" uuid="8b84e958-3fc6-4820-b9f0-3252ef723e24">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
@@ -162,7 +162,7 @@
 			<line>
 				<reportElement x="1" y="103" width="519" height="1" uuid="8e62d3e5-771e-4ce1-bf3e-816f4a4789f0"/>
 			</line>
-			<staticText>
+			<textField>
 				<reportElement x="0" y="106" width="49" height="20" uuid="9ec480a6-777e-401b-a748-cd9b2829d132">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
@@ -173,53 +173,53 @@
 					<font size="12"/>
 					<paragraph rightIndent="2"/>
 				</textElement>
-				<text><![CDATA[$R{name.label}]]></text>
-			</staticText>
-			<staticText>
+				<textFieldExpression><![CDATA[$R{name.label}]]></textFieldExpression>
+			</textField>
+			<textField>
 				<reportElement x="0" y="130" width="40" height="14" uuid="3948376e-3643-40c1-85d0-19bd14241512">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 				</reportElement>
-				<text><![CDATA[$R{street.label}]]></text>
-			</staticText>
-			<staticText>
+				<textFieldExpression><![CDATA[$R{street.label}]]></textFieldExpression>
+			</textField>
+			<textField>
 				<reportElement x="0" y="150" width="40" height="14" uuid="5c32d00f-85a6-4007-8ffe-4e95c9a24b8d">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 				</reportElement>
-				<text><![CDATA[$R{zip.label}]]></text>
-			</staticText>
-			<staticText>
+				<textFieldExpression><![CDATA[$R{zip.label}]]></textFieldExpression>
+			</textField>
+			<textField>
 				<reportElement x="98" y="150" width="20" height="14" uuid="24d09957-be27-4033-8e86-78102f0a8b15">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
-				<text><![CDATA[$R{city.label}]]></text>
-			</staticText>
-			<staticText>
+				<textFieldExpression><![CDATA[$R{city.label}]]></textFieldExpression>
+			</textField>
+			<textField>
 				<reportElement x="104" y="80" width="20" height="14" uuid="ae980231-70a8-4cb5-92a7-f4467dd283d9">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
-				<text><![CDATA[$R{city.label}]]></text>
-			</staticText>
-			<staticText>
+				<textFieldExpression><![CDATA[$R{city.label}]]></textFieldExpression>
+			</textField>
+			<textField>
 				<reportElement x="0" y="80" width="40" height="14" uuid="28f58eec-f1cc-44ab-be3e-05cdc3a332b5">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 				</reportElement>
-				<text><![CDATA[$R{zip.label}]]></text>
-			</staticText>
-			<staticText>
+				<textFieldExpression><![CDATA[$R{zip.label}]]></textFieldExpression>
+			</textField>
+			<textField>
 				<reportElement x="0" y="60" width="50" height="14" uuid="6d3d9af1-0683-40ce-9611-124205eb3cd8">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 				</reportElement>
-				<text><![CDATA[$R{street.label}]]></text>
-			</staticText>
-			<staticText>
+				<textFieldExpression><![CDATA[$R{street.label}]]></textFieldExpression>
+			</textField>
+			<textField>
 				<reportElement x="0" y="30" width="51" height="20" uuid="96e641e3-de36-498c-b481-52d147069df2">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
@@ -230,8 +230,8 @@
 					<font size="12"/>
 					<paragraph rightIndent="2"/>
 				</textElement>
-				<text><![CDATA[$R{name.label}]]></text>
-			</staticText>
+				<textFieldExpression><![CDATA[$R{name.label}]]></textFieldExpression>
+			</textField>
 		</band>
 	</pageHeader>
 	<columnHeader>
@@ -264,13 +264,13 @@
 	</detail>
 	<summary>
 		<band height="188" splitType="Stretch">
-			<staticText>
+			<textField>
 				<reportElement x="1" y="74" width="139" height="30" uuid="1716e357-e044-4485-bf5b-3efaf7cc6aab"/>
 				<textElement>
 					<font size="14" isBold="true"/>
 				</textElement>
-				<text><![CDATA[$R{bank.details}]]></text>
-			</staticText>
+				<textFieldExpression><![CDATA[$R{bank.details}]]></textFieldExpression>
+			</textField>
 			<staticText>
 				<reportElement x="0" y="100" width="81" height="21" uuid="a7a5c622-62e8-4d47-8c2b-1558f032a6a6"/>
 				<textElement>
@@ -285,7 +285,7 @@
 				</textElement>
 				<text><![CDATA[BIC/SWIFT:]]></text>
 			</staticText>
-			<staticText>
+			<textField>
 				<reportElement x="350" y="71" width="122" height="30" uuid="41d4f5bd-7868-4753-8011-3404ac8034b1">
 					<printWhenExpression><![CDATA[$F{supplierTaxNumber} != null]]></printWhenExpression>
 				</reportElement>
@@ -295,8 +295,8 @@
 				<textElement>
 					<font size="14" isBold="true"/>
 				</textElement>
-				<text><![CDATA[$R{tax.number}]]></text>
-			</staticText>
+				<textFieldExpression><![CDATA[$R{tax.number}]]></textFieldExpression>
+			</textField>
 			<textField>
 				<reportElement x="0" y="142" width="220" height="21" uuid="36994d9b-ab9a-4232-965c-60d7ad9bc37f"/>
 				<textElement>


### PR DESCRIPTION
### Motivation
- Recent changes turned several labels into resource keys like `$R{...}` but left them inside `<staticText>`, which JasperReports does not evaluate, causing literal `$R{...}` to appear in PDFs. 
- The intent is to ensure all localized keys are evaluatable by moving them into expression-capable tags so translations render correctly at runtime.

### Description
- Converted `<staticText>` elements that contained `$R{...}` into `<textField>` elements and moved the resource key into `<textFieldExpression>` while preserving the original `reportElement` coordinates, sizes, UUIDs and all text styling. 
- Updated files: `ordermanager-backend/src/main/resources/invoice.jrxml` and `ordermanager-backend/src/main/resources/invoice-data.jrxml`. 
- Total converted elements: 19 localized labels (12 conversions in `invoice.jrxml`, 7 conversions in `invoice-data.jrxml`) including title, address/project labels, table column headers and summary labels (e.g., `invoice.title`, `project.label`, `item.description`, `invoice.amount.total`, `bank.details`, `tax.number`, etc.).
- Preserved existing formatting and any non-localized `staticText` (hardcoded text like currency symbols) was left unchanged.

### Testing
- Ran a targeted scan to confirm no `<staticText>` blocks contain `$R{...}` anymore using a Python script and `rg -n -F '$R{'` against the JRXML resources, and both checks returned no remaining offending cases. (succeeded)
- Verified `$R{...}` references now appear inside `textFieldExpression` or other evaluatable expression tags by inspecting the modified JRXMLs. (succeeded)
- Attempted a Maven build with `mvn -pl ordermanager-backend -DskipTests compile` to validate compilation and PDF generation but it was blocked by an environment artifact fetch error from Maven Central (HTTP 403), so full compile/PDF generation could not be executed here. (blocked)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e486098968832bbcf8df5912ed1134)