### PR TITLE
Add Node.js TypeScript backend scaffold for ordermanager-ui (preserve /frontend API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ The user manual for the application is located in the project path ```ordermanag
   - Java: 
       Currently default version of java for compile and target is 21
   - Docker Images:
-     - JDK openjdk:21-jdk
+     - JDK eclipse-temurin:21-jdk
+     - node:20-alpine for node-frontend image
+
 If you want to use another java then you need to change java versions in both pom.xm (backend and frontend modules) and
 in docker files need also change the version of JDK image.
 
@@ -52,11 +54,19 @@ and
 ````/ordermanager/docker/frontend````
 
       
-# Deploy to docker
+# Create images and deploy to docker
  - please go to folder ./docker and follow with description in README_DOCKER.md) file
+## Variant 1: manual
  - 1\. create backend image with correspondent version
  - 2\. create frontend image with correspondent version  
  - 3\. run docker-compose (see ./docker/README_DOCKER.md)
+## Variant 2: with Maven profile
+ - go to the maven module `odermanager-parent` than build the project with profiles
+ - first select profile `build-angular`
+ - select profile `with-docker-linux` or `with-docker-windows`
+The full script: ```mvn clean install -Pbuild-angular -Pwith-docker-linux```
+
+
 # Short description
 The project is primarily created to gather useful features for both the frontend 
 and backend components based on a real application. The user manual for the application is located in the project path ```ordermanager/doc```. 

--- a/docker/delete-start.bat
+++ b/docker/delete-start.bat
@@ -27,6 +27,10 @@ docker build -t prognimak.ordermanager/frontend:002 %BASEDIR%/frontend
 REM create eureka image
 docker build -t prognimak.ordermanager/discovery:002  %BASEDIR%/discovery
 
+REM creates frontend image on basis of NodeJs server
+docker build -t prognimak.ordermanager/node-frontend:002 %BASEDIR%/node_frontend
+
+
 REM create postgres image. It is commented first because
 REM docker build -t prognimak.ordermanager/postgres:14  %BASEDIR%/db
 

--- a/docker/delete-start.sh
+++ b/docker/delete-start.sh
@@ -15,6 +15,8 @@ docker build -t prognimak.ordermanager/backend:001 ./backend
 docker build -t prognimak.ordermanager/frontend:002 ./frontend
 # creates eureke image
 docker build -t prognimak.ordermanager/discovery:002 ./discovery
+# creates frontend image on basis of NodeJs server
+docker build -t prognimak.ordermanager/node-frontend:002 ./node_frontend
 
 # creates postgres image
 #docker build -t prognimak.ordermanager/postgres:14 ./db

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
     - 8083:8083
     volumes:
       - vol-ordermanager:/data/ordermanager-backend
-##### UI
+##### UI with SpringBoot server
   ordermanager-ui:
     depends_on:
     - postgres
@@ -61,9 +61,23 @@ services:
       - 8082:8082
     volumes:
       - vol-ordermanager-ui:/data/ordermanager-ui
-
+##### UI with NodeJS server
+  ordermanager-node_ui:
+    depends_on:
+      - postgres
+      - discovery
+      - ordermanager
+    hostname: ordermanager-node_ui
+    image: prognimak.ordermanager/node-frontend:002
+    networks:
+      nw_prognimak: null
+    ports:
+      - 8085:8085
+    volumes:
+      - vol-ordermanager-node_ui:/data/ordermanager-node_ui
  #### Volumes
 volumes:
   vol-postgres2: {}
   vol-ordermanager: {}
   vol-ordermanager-ui: {}
+  vol-ordermanager-node_ui: {}

--- a/docker/node_frontend/.dockerignore
+++ b/docker/node_frontend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/docker/node_frontend/.gitignore
+++ b/docker/node_frontend/.gitignore
@@ -1,0 +1,1 @@
+src-node

--- a/docker/node_frontend/Dockerfile
+++ b/docker/node_frontend/Dockerfile
@@ -1,0 +1,14 @@
+# Stage 1 Node
+FROM node:20-alpine
+
+WORKDIR /app
+
+# install only production deps
+COPY src-node/package*.json ./
+RUN npm ci --omit=dev
+
+# copy only runtime files
+COPY src-node/dist ./dist
+COPY src-node/public ./public
+
+CMD ["npm", "start"]

--- a/docker/node_frontend/README_DOCKER.md
+++ b/docker/node_frontend/README_DOCKER.md
@@ -1,0 +1,28 @@
+### Build docker image
+To build docker image runs this script from location of Dockerfile
+````
+docker build -t prognimak.ordermanager/node_frontend:<version> .
+````
+### Run docker image
+
+If wants to run only ordermanager image than run that script
+```
+ docker run  prognimak.ordermanager/node_frontend
+```
+
+### Run docker-compose
+To run docker compose with postgresql data base and orderimage backend application
+```
+ docker-compose -f docker-compose.yaml up -d
+```
+
+### Deploy with docker stack
+To deploy docker stack with postgresql data base and orderimage backend application.
+Before need to init SWARM. Run command:
+```
+docker swarm init
+```
+then run
+```
+ docker stack deploy -c docker-compose.yaml my-stack
+```

--- a/ordermanager-ui/pom.xml
+++ b/ordermanager-ui/pom.xml
@@ -101,6 +101,20 @@
         <configuration>
           <filesets>
             <fileset>
+              <directory>${basedir}/src-node/dist</directory>
+              <includes>
+                <include>**/*</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+            <fileset>
+              <directory>${basedir}/src-node/public</directory>
+              <includes>
+                <include>**/*</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+            <fileset>
               <directory>${basedir}/src/main/resources/static</directory>
               <includes>
                 <include>**/*</include>
@@ -136,6 +150,7 @@
             </goals>
             <configuration>
               <target>
+                <delete dir="../docker/node_frontend/src-node" failonerror="false"/>
                 <delete>
                   <fileset dir="../docker/frontend" includes="*.jar"/>
                 </delete>
@@ -199,6 +214,7 @@
             <groupId>org.codehaus.mojo</groupId>
             <version>3.3.0</version>
             <executions>
+
               <execution>
                 <id>angular-cli build</id>
                 <phase>validate</phase>
@@ -216,6 +232,21 @@
                     <argument>--base-href=/${app.baseurl}/</argument>
                   </arguments>
                   <workingDirectory>ui/resources/frontend/invoices</workingDirectory>
+                </configuration>
+              </execution>
+              <execution>
+                <id>npm-build</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>npm</executable>
+                  <arguments>
+                    <argument>run</argument>
+                    <argument>build</argument>
+                  </arguments>
+                  <workingDirectory>src-node</workingDirectory>
                 </configuration>
               </execution>
             </executions>
@@ -237,6 +268,44 @@
                       <directory>${basedir}/ui/resources/frontend/invoices/dist</directory>
                       <excludes>
                         <exclude>/node_modules/**</exclude>
+                      </excludes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+              <execution>
+                <id>copy-node-dir</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${basedir}/src-node/public</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${basedir}/ui/resources/frontend/invoices/dist</directory>
+                      <excludes>
+                        <exclude>/node_modules/**</exclude>
+                      </excludes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+              <execution>
+                <id>copy-node-dir-to-docker</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>../docker/node_frontend/src-node</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${basedir}/src-node</directory>
+                      <excludes>
+                        <exclude>/node_modules/**</exclude>
+                        <exclude>/src/**</exclude>
+                        <exclude>/test/**</exclude>
                       </excludes>
                     </resource>
                   </resources>

--- a/ordermanager-ui/src-node/README.md
+++ b/ordermanager-ui/src-node/README.md
@@ -1,0 +1,26 @@
+# ordermanager-ui/src-node
+
+Node.js + TypeScript replacement for the `ordermanager-ui` Spring Boot backend.
+
+## Implemented compatibility
+
+- `GET /frontend/backendUrl` -> `{ "url": "..." }`
+- Static serving under `/frontend`
+- `GET /frontend/management/health`
+
+## Environment variables
+
+- `PORT` (default: `8082`)
+- `CONTEXT_PATH` (default: `/frontend`)
+- `APP_BACKEND_URL` (preferred backend URL)
+- `BACKEND_MICROCERVICE_URL` (legacy-compatible fallback name)
+- `STATIC_DIR` (path to Angular build output)
+
+## Commands
+
+```bash
+npm install
+npm run build
+npm start
+npm test
+```

--- a/ordermanager-ui/src-node/docs/MIGRATION_REPORT.md
+++ b/ordermanager-ui/src-node/docs/MIGRATION_REPORT.md
@@ -1,0 +1,124 @@
+# ordermanager-ui Java ➜ Node.js Migration Report
+
+## 1) Spring Boot backend inspection (`ordermanager-ui/src`)
+
+### Application bootstrap
+- `AngularFrontendApplication` is the only Spring Boot application class.
+- It starts on port `8082` under context path `/frontend`.
+- It excludes JDBC and Spring Security auto-configuration.
+
+### Controllers
+- Only one controller endpoint exists in this module:
+  - `GET /backendUrl` (effective URL: `/frontend/backendUrl`) returning `{ "url": "..." }`.
+
+### Services / repositories / DTOs / entities
+- No service layer classes in this module.
+- No JPA repositories in this module.
+- One DTO-like model exists: `UrlTransfer { url: string }`.
+- No domain entities are implemented in this module.
+
+### Config
+- `application.properties` defines:
+  - `server.port=8082`
+  - `server.servlet.context-path=/frontend`
+  - `backend.microcervice.url` (note original typo)
+  - `app.backend.url` fallback to Azure backend URL
+  - actuator and eureka properties.
+
+### Security
+- Spring Security is intentionally excluded for this module.
+- The only role of this backend is providing backend URL discovery and static UI hosting.
+
+### Schedulers/jobs
+- None found.
+
+### File/report/PDF logic
+- None found in this module.
+- PDF/report logic is consumed by Angular against the remote backend URL (`invoice/printreport`) and belongs to another service.
+
+## 2) Angular backend usage inspection (`ordermanager-ui/ui`)
+
+### URL bootstrap behavior
+- Angular calls `GET backendUrl` (relative URL) at startup.
+- On success, it stores `response.url` to `localStorage.remoteBackendURL`.
+- On failure, it falls back to `environment.baseUrl`.
+
+### Auth/session behavior against remote backend
+- Login: `POST {remoteBackendURL}login` with `Login-Credentials` header.
+- Session check: `GET {remoteBackendURL}checkUser`.
+- Logout: `POST {remoteBackendURL}perform_logout`.
+- Basic auth token is stored in localStorage and attached by interceptor.
+
+### API contract expectations
+- UI expects this module to expose exactly a JSON object with `url` field.
+- Remaining invoice/person/catalog/report endpoints are called directly against `remoteBackendURL`.
+
+### File/PDF behavior
+- Angular requests PDF via `POST {remoteBackendURL}invoice/printreport` as blob and opens returned PDF in browser.
+- No upload handling in this module.
+
+## 3) Node.js replacement design
+
+### Selected stack
+- Node.js + TypeScript + Express.
+- Modular split:
+  - `config` (`env.ts`)
+  - `controllers` (`backend-url.controller.ts`, `management.controller.ts`)
+  - `middleware` (`error-handler.ts`)
+  - `app.ts` composition + `main.ts` bootstrap
+
+### Contract-preserving decisions
+- Keep same context path default: `/frontend`.
+- Keep endpoint path and payload:
+  - `GET /frontend/backendUrl` -> `{ "url": string }`.
+- Preserve legacy property naming compatibility (including typo):
+  - `BACKEND_MICROCERVICE_URL` (maps old `backend.microcervice.url`).
+  - `APP_BACKEND_URL` overrides it.
+- Keep static hosting and SPA fallback under `/frontend/*`.
+- Add lightweight health endpoint `/frontend/management/health` for operational parity with old actuator health checks.
+
+## 4) Implementation progress
+
+### Completed
+- Created new backend scaffold in `ordermanager-ui/src-node`.
+- Implemented environment-based config and endpoint compatibility.
+- Implemented Express bootstrap and error-handling middleware.
+- Added compatibility tests with `supertest` + `vitest`.
+
+### In-progress / pending
+- Runtime validation in this environment was blocked by restricted npm registry access (`403` on package install).
+
+## 5) Unresolved gaps
+
+1. **Eureka client integration**
+   - Spring version had eureka properties; Node scaffold does not yet register with discovery service.
+2. **Actuator breadth**
+   - Only `/management/health` was mirrored, not full actuator surface.
+3. **Container/build wiring**
+   - Existing Maven/docker flow still packages Java service; CI/CD must be updated to build `src-node` runtime image.
+
+## 6) Deployment steps (proposed)
+
+1. Build Angular assets as before.
+2. Build Node service:
+   - `cd ordermanager-ui/src-node`
+   - `npm ci && npm run build`
+3. Run with env:
+   - `PORT=8082`
+   - `CONTEXT_PATH=/frontend`
+   - `APP_BACKEND_URL=...` (or `BACKEND_MICROCERVICE_URL=...`)
+   - `STATIC_DIR=/path/to/angular/dist`
+4. Smoke test:
+   - `GET /frontend/backendUrl`
+   - `GET /frontend/management/health`
+   - open `/frontend/` and verify Angular loads.
+
+## 7) Rollback plan
+
+1. Keep existing Spring Boot artifact and deployment descriptors untouched.
+2. Deploy Node backend behind a toggle / separate deployment slot.
+3. If any compatibility issue appears:
+   - route traffic back to Spring service,
+   - keep Angular unchanged,
+   - compare `/frontend/backendUrl` responses and logs.
+4. Roll forward after patching Node compatibility gaps.

--- a/ordermanager-ui/src-node/package.json
+++ b/ordermanager-ui/src-node/package.json
@@ -20,6 +20,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/node": "^22.10.2",
+    "@types/supertest": "^7.2.0",
     "supertest": "^7.1.1",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",

--- a/ordermanager-ui/src-node/package.json
+++ b/ordermanager-ui/src-node/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "ordermanager-ui-node-backend",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Node.js replacement for ordermanager-ui Spring Boot backend",
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/main.js",
+    "dev": "tsx watch src/main.ts",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "helmet": "^7.1.0"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/node": "^22.10.2",
+    "supertest": "^7.1.1",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/ordermanager-ui/src-node/src/app.ts
+++ b/ordermanager-ui/src-node/src/app.ts
@@ -1,0 +1,28 @@
+import express, { Express } from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import path from 'node:path';
+import { loadEnv } from './config/env';
+import { backendUrlRouter } from './controllers/backend-url.controller';
+import { managementRouter } from './controllers/management.controller';
+import { errorHandler } from './middleware/error-handler';
+
+export const createApp = (): { app: Express; env: ReturnType<typeof loadEnv> } => {
+  const env = loadEnv();
+  const app = express();
+
+  app.use(helmet({ contentSecurityPolicy: false }));
+  app.use(cors());
+  app.use(express.json());
+
+  app.use(env.contextPath, backendUrlRouter(env));
+  app.use(env.contextPath, managementRouter());
+
+  app.use(env.contextPath, express.static(env.staticDir));
+  app.get(`${env.contextPath}/*`, (_req, res) => {
+    res.sendFile(path.join(env.staticDir, 'index.html'));
+  });
+
+  app.use(errorHandler);
+  return { app, env };
+};

--- a/ordermanager-ui/src-node/src/config/env.ts
+++ b/ordermanager-ui/src-node/src/config/env.ts
@@ -1,0 +1,33 @@
+import path from 'node:path';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const DEFAULT_BACKEND_URL = 'https://prognimak-ordermanager-backend.azurewebsites.net/backend/';
+const DEFAULT_MICROSERVICE_URL = 'http://localhost:8083/backend/';
+
+const normalizeContextPath = (input: string | undefined): string => {
+  if (!input || input.trim().length === 0) return '/frontend';
+  const trimmed = input.trim();
+  const prefixed = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  return prefixed.endsWith('/') ? prefixed.slice(0, -1) : prefixed;
+};
+
+export type AppEnv = {
+  port: number;
+  contextPath: string;
+  backendBaseUrl: string;
+  staticDir: string;
+};
+
+export const loadEnv = (): AppEnv => {
+  const microserviceUrl = process.env.BACKEND_MICROCERVICE_URL ?? DEFAULT_MICROSERVICE_URL;
+  const backendBaseUrl = process.env.APP_BACKEND_URL ?? microserviceUrl ?? DEFAULT_BACKEND_URL;
+
+  return {
+    port: Number(process.env.PORT ?? 8082),
+    contextPath: normalizeContextPath(process.env.CONTEXT_PATH),
+    backendBaseUrl,
+    staticDir: process.env.STATIC_DIR ?? path.resolve(__dirname, '../../public')
+  };
+};

--- a/ordermanager-ui/src-node/src/config/env.ts
+++ b/ordermanager-ui/src-node/src/config/env.ts
@@ -25,9 +25,9 @@ export const loadEnv = (): AppEnv => {
   const backendBaseUrl = process.env.APP_BACKEND_URL ?? microserviceUrl ?? DEFAULT_BACKEND_URL;
 
   return {
-    port: Number(process.env.PORT ?? 8082),
+    port: Number(process.env.PORT ?? 8085),
     contextPath: normalizeContextPath(process.env.CONTEXT_PATH),
     backendBaseUrl,
-    staticDir: process.env.STATIC_DIR ?? path.resolve(__dirname, '../../public')
+    staticDir: process.env.STATIC_DIR ?? path.resolve(__dirname, '../../public/static')
   };
 };

--- a/ordermanager-ui/src-node/src/controllers/backend-url.controller.ts
+++ b/ordermanager-ui/src-node/src/controllers/backend-url.controller.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { AppEnv } from '../config/env';
+
+export const backendUrlRouter = (env: AppEnv): Router => {
+  const router = Router();
+
+  router.get('/backendUrl', (_req, res) => {
+    res.json({ url: env.backendBaseUrl });
+  });
+
+  return router;
+};

--- a/ordermanager-ui/src-node/src/controllers/management.controller.ts
+++ b/ordermanager-ui/src-node/src/controllers/management.controller.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+
+export const managementRouter = (): Router => {
+  const router = Router();
+
+  router.get('/management/health', (_req, res) => {
+    res.json({ status: 'UP' });
+  });
+
+  return router;
+};

--- a/ordermanager-ui/src-node/src/main.ts
+++ b/ordermanager-ui/src-node/src/main.ts
@@ -1,0 +1,8 @@
+import { createApp } from './app';
+
+const { app, env } = createApp();
+
+app.listen(env.port, () => {
+  // eslint-disable-next-line no-console
+  console.log(`ordermanager-ui Node backend running on port ${env.port}${env.contextPath}`);
+});

--- a/ordermanager-ui/src-node/src/middleware/error-handler.ts
+++ b/ordermanager-ui/src-node/src/middleware/error-handler.ts
@@ -1,0 +1,10 @@
+import { NextFunction, Request, Response } from 'express';
+
+export const errorHandler = (err: Error, _req: Request, res: Response, _next: NextFunction): void => {
+  res.status(500).json({
+    timestamp: new Date().toISOString(),
+    status: 500,
+    error: 'Internal Server Error',
+    message: err.message
+  });
+};

--- a/ordermanager-ui/src-node/test/backend-compatibility.test.ts
+++ b/ordermanager-ui/src-node/test/backend-compatibility.test.ts
@@ -1,0 +1,42 @@
+import request from 'supertest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createApp } from '../src/app';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('Spring compatibility contract', () => {
+  it('exposes GET /frontend/backendUrl with {url}', async () => {
+    vi.stubEnv('CONTEXT_PATH', '/frontend');
+    vi.stubEnv('APP_BACKEND_URL', 'http://localhost:8083/backend/');
+
+    const { app } = createApp();
+    const response = await request(app).get('/frontend/backendUrl');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ url: 'http://localhost:8083/backend/' });
+  });
+
+  it('keeps Spring style fallback from BACKEND_MICROCERVICE_URL', async () => {
+    vi.stubEnv('CONTEXT_PATH', '/frontend');
+    vi.stubEnv('APP_BACKEND_URL', '');
+    vi.stubEnv('BACKEND_MICROCERVICE_URL', 'https://example.invalid/backend/');
+
+    const { app } = createApp();
+    const response = await request(app).get('/frontend/backendUrl');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ url: 'https://example.invalid/backend/' });
+  });
+
+  it('exposes /frontend/management/health for runtime checks', async () => {
+    vi.stubEnv('CONTEXT_PATH', '/frontend');
+    const { app } = createApp();
+
+    const response = await request(app).get('/frontend/management/health');
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('UP');
+  });
+});

--- a/ordermanager-ui/src-node/tsconfig.json
+++ b/ordermanager-ui/src-node/tsconfig.json
@@ -10,5 +10,6 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["test", "**/*.test.ts"]
 }

--- a/ordermanager-ui/src-node/tsconfig.json
+++ b/ordermanager-ui/src-node/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/ordermanager-ui/src-node/vitest.config.ts
+++ b/ordermanager-ui/src-node/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts']
+  }
+});


### PR DESCRIPTION
### Motivation

- Replace the small Spring Boot frontend helper in `ordermanager-ui/src` with a Node.js backend while preserving the exact API contract used by the Angular app. 
- Keep the Angular UI under `ordermanager-ui/ui` unchanged and provide the same discovery endpoint and static hosting behavior so the frontend continues to work without modification. 
- Provide an environment-driven, modular Node/TypeScript scaffold that can be incrementally expanded to fully replace the Java runtime.

### Description

- Added a new Node.js + TypeScript backend scaffold at `ordermanager-ui/src-node` including `package.json`, `tsconfig.json`, `vitest.config.ts`, and source layout (`src/config`, `src/controllers`, `src/middleware`, `src/main.ts`, `src/app.ts`).
- Implemented environment-based configuration in `src/config/env.ts` supporting `APP_BACKEND_URL` (preferred) and legacy `BACKEND_MICROCERVICE_URL` names and preserving default values consistent with the Java app.
- Implemented compatibility controllers: `GET /frontend/backendUrl` returning `{ url: "..." }` in `src/controllers/backend-url.controller.ts`, and a lightweight health check at `/frontend/management/health` in `src/controllers/management.controller.ts`; static SPA serving and SPA-fallback are wired under the same context path in `src/app.ts`.
- Added minimal error handling middleware (`src/middleware/error-handler.ts`), a startup entry (`src/main.ts`), compatibility-focused tests (`test/backend-compatibility.test.ts` using Vitest + Supertest), and documentation (`README.md`, `docs/MIGRATION_REPORT.md`) describing mapping, progress, and deployment/rollback steps.

### Testing

- Added automated compatibility tests under `ordermanager-ui/src-node/test` which assert `GET /frontend/backendUrl` returns the expected `{ url }` payload and the fallback from `BACKEND_MICROCERVICE_URL`, and that `/frontend/management/health` returns `status: 'UP'` (tests use `vitest` + `supertest`).
- Attempted to run dependency installation (`cd ordermanager-ui/src-node && npm install`) in this environment but it failed due to npm registry access returning `403 Forbidden`, so the test suite was not executed here. 
- The test artifacts and `npm` scripts (`build`, `start`, `test`) are present and ready to run in an environment with npm registry access using `npm install && npm run test` or `npm run build && npm start`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ab889028832bb36521def1852ae4)