### PR TITLE
fix(node-dto): replace unsupported IsNotNull with IsDefined in NestJS DTOs

### DIFF
--- a/ordermanager-backend/src-node/src/invoice/dto/invoice.dto.ts
+++ b/ordermanager-backend/src-node/src/invoice/dto/invoice.dto.ts
@@ -1,7 +1,7 @@
-import { IsArray, IsNotEmpty, IsNotNull, IsNumber, IsOptional, IsPositive, IsString } from 'class-validator';
+import { IsArray, IsNotEmpty, IsDefined, IsNumber, IsOptional, IsPositive, IsString } from 'class-validator';
 
 export class InvoiceItemModelDto {
-  @IsNotNull() id!: number;
+  @IsDefined() id!: number;
   catalogItemId?: number;
   description?: string;
   @IsNumber() @IsPositive() amountItems!: number;
@@ -23,14 +23,14 @@ export class InvoiceFormModelDto {
   id?: number;
   @IsString() @IsNotEmpty() invoiceNumber!: string;
   invoiceDescription?: string;
-  @IsNotNull() personSupplierId!: number;
-  @IsNotNull() personRecipientId!: number;
+  @IsDefined() personSupplierId!: number;
+  @IsDefined() personRecipientId!: number;
   supplierFullName?: string;
   recipientFullName?: string;
   totalSumNetto?: number;
   totalSumBrutto?: number;
-  @IsNotNull() creationDate!: string;
-  @IsNotNull() invoiceDate!: string;
+  @IsDefined() creationDate!: string;
+  @IsDefined() invoiceDate!: string;
   @IsString() @IsNotEmpty() rateType!: string;
   @IsArray() invoiceItems!: InvoiceItemModelDto[];
 }

--- a/ordermanager-backend/src-node/src/person/dto/person.dto.ts
+++ b/ordermanager-backend/src-node/src/person/dto/person.dto.ts
@@ -1,6 +1,5 @@
-import { IsEmail, IsString, IsNotEmpty, IsNotNull } from 'class-validator';
+import { IsDefined, IsEmail, IsNotEmptyObject, IsOptional, IsString } from 'class-validator';
 import { PersonType } from '../entities/person-type.enum';
-import { IsNotEmptyObject, IsOptional, IsString } from 'class-validator';
 
 export class PersonAddressFormModelDto {
   id?: number;
@@ -23,7 +22,7 @@ export class PersonFormModelDto {
   personLastName?: string;
   personFirstName?: string;
   companyName?: string;
-  @IsNotNull() personType!: PersonType;
+  @IsDefined() personType!: PersonType;
   taxNumber?: string;
   @IsEmail() email!: string;
   @IsNotEmptyObject() personAddressFormModel!: PersonAddressFormModelDto;


### PR DESCRIPTION
### Motivation
- The generated NestJS DTOs used `@IsNotNull()` which is not exported by `class-validator`, causing runtime/compile failures. 
- `@IsDefined()` is the correct strict replacement for Java/Spring `@NotNull` while preserving API contracts. 
- Changes are scoped to the Node backend DTOs and do not modify Java/Spring code or DTO field names. 

### Description
- Removed `IsNotNull` imports and added `IsDefined` to `class-validator` imports where required. 
- Replaced all `@IsNotNull()` decorators with `@IsDefined()` in the generated DTOs under `ordermanager-backend/src-node/src`. 
- Updated `ordermanager-backend/src-node/src/person/dto/person.dto.ts` and `ordermanager-backend/src-node/src/invoice/dto/invoice.dto.ts` accordingly while keeping DTO class and field names unchanged. 

### Testing
- Ran repository searches with `rg` to confirm no `IsNotNull` occurrences remain and that `@IsDefined()` appears in the updated DTOs, which succeeded. 
- Inspected the `git diff` output to verify only the intended DTO files changed, which succeeded. 
- Committed the changes with `git commit` to record the fix, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecaa6ce730832b803695f981af570a)