### PR TITLE
Fix login header decoding and add safe login debug logging

### DIFF
--- a/ordermanager-backend/src-node/src/security/services/auth.service.ts
+++ b/ordermanager-backend/src-node/src/security/services/auth.service.ts
@@ -1,21 +1,24 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { LoginResultResponseDto } from '../dto/login-result.dto';
 import { JwtTokenService } from './jwt.service';
 import { UserService } from './user.service';
 
 @Injectable()
 export class AuthService {
+  private readonly logger = new Logger(AuthService.name);
+
   constructor(
     private readonly userService: UserService,
     private readonly jwtTokenService: JwtTokenService,
   ) {}
 
   async loginWithHeader(loginCredential: string | undefined): Promise<LoginResultResponseDto> {
+    this.logger.debug(`Login header present: ${Boolean(loginCredential)}`);
     if (!loginCredential) {
       return new LoginResultResponseDto(false, null);
     }
 
-    const decoded = Buffer.from(loginCredential, 'base64').toString('utf-8');
+    const decoded = this.decodeLoginCredential(loginCredential);
     const separatorIndex = decoded.indexOf(':');
     if (separatorIndex <= 0) {
       return new LoginResultResponseDto(false, null);
@@ -23,6 +26,7 @@ export class AuthService {
 
     const username = decoded.slice(0, separatorIndex);
     const password = decoded.slice(separatorIndex + 1);
+    this.logger.debug(`Login username decoded: ${username || '<empty>'}`);
     if (!username || !password) {
       return new LoginResultResponseDto(false, null);
     }
@@ -37,6 +41,19 @@ export class AuthService {
       return new LoginResultResponseDto(true, token);
     } catch {
       return new LoginResultResponseDto(false, null);
+    }
+  }
+
+  private decodeLoginCredential(loginCredential: string): string {
+    if (loginCredential.includes(':')) {
+      return loginCredential;
+    }
+
+    try {
+      const base64Decoded = Buffer.from(loginCredential, 'base64').toString('utf-8');
+      return base64Decoded.includes(':') ? base64Decoded : loginCredential;
+    } catch {
+      return loginCredential;
     }
   }
 }

--- a/ordermanager-backend/src-node/src/security/services/user.service.ts
+++ b/ordermanager-backend/src-node/src/security/services/user.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 import { ErrorCode } from '../../exception/error-code.enum';
 import { OrderManagerException } from '../../exception/order-manager.exception';
@@ -8,6 +8,8 @@ import { UserRepository } from '../repositories/user.repository';
 
 @Injectable()
 export class UserService {
+  private readonly logger = new Logger(UserService.name);
+
   constructor(
     private readonly userRepository: UserRepository,
     private readonly roleRepository: RoleRepository,
@@ -22,8 +24,14 @@ export class UserService {
   }
 
   async validatePassword(username: string, password: string): Promise<InvoiceUserEntity | null> {
-    const user = await this.getUserOrException(username);
+    const user = await this.userRepository.findByUsername(username);
+    this.logger.debug(`Login user found for "${username}": ${Boolean(user)}`);
+    if (!user) {
+      return null;
+    }
+
     const valid = await bcrypt.compare(password, user.password);
+    this.logger.debug(`bcrypt password comparison succeeded for "${username}": ${valid}`);
     return valid ? user : null;
   }
 


### PR DESCRIPTION
### Motivation
- The login endpoint always failed to authenticate because the backend assumed the `Login-Credentials` header was Base64 and did not handle plain `username:password` input, causing `POST /backend/login` to return `{ logged: false }`.
- Temporary, safe debug information was needed to diagnose the login flow without exposing raw passwords or JWTs.

### Description
- Added a `Logger` to `AuthService` and `UserService` and introduced debug logs for header presence and decoded username in `AuthService` and for user lookup and bcrypt comparison result in `UserService`.
- Implemented `decodeLoginCredential` in `AuthService` to accept either a plain `username:password` string or a Base64-encoded `username:password` value and to fall back safely when decoding fails.
- Adjusted `UserService.validatePassword` to log and return `null` when the user is not found and to log the boolean result of `bcrypt.compare(password, user.password)` while preserving the original `validatePassword` semantics.
- Preserved the login response DTO and shape (`{ logged: boolean, token: string | null }`) and left controller header binding as `@Headers('login-credentials')` unchanged.

### Testing
- Built the backend TypeScript project with `npm run build` in `ordermanager-backend/src-node`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edad8f22b0832b9ba7e28be7c62ece)